### PR TITLE
Add support for Exynos HDMI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,13 @@ AC_ARG_WITH([tda995x-toolkit-path],
   [TDA995X_CFLAGS="-I$withval/inc"],
   [TDA995X_CFLAGS="-I\$(abs_top_srcdir)/nxp_hdmi/inc"])
 
+## Exynos support
+AC_ARG_ENABLE([exynos],
+  [AS_HELP_STRING([--enable-exynos],
+  [enable support for the Exynos (default is yes)])],
+  [use_exynos=$enableval],
+  [use_exynos=yes])
+
 ## Raspberry Pi support
 AC_ARG_ENABLE([rpi],
   [AS_HELP_STRING([--enable-rpi],
@@ -269,6 +276,19 @@ else
   AM_CONDITIONAL(USE_TDA995X_API, false)
   features="$features\n  TDA995x support :\t\t\tno"
 fi
+
+## mark Exynos support as available
+if test "x$use_exynos" != "xno"; then
+  AC_DEFINE([HAVE_EXYNOS_API],[1],[Define to 1 to include Exynos support])
+  AM_CONDITIONAL(USE_EXYNOS_API, true)
+  features="$features\n  Exynos support :\t\t\tyes"
+  LIB_INFO="$LIB_INFO 'EXYNOS'"
+  CPPFLAGS="$CPPFLAGS $EXYNOS_CFLAGS"
+else
+  AM_CONDITIONAL(USE_EXYNOS_API, false)
+  features="$features\n  EXYNOS support :\t\t\tno"
+fi
+
 
 ## check if our build system is complete
 AC_CHECK_HEADER(algorithm,,AC_MSG_ERROR($msg_required_header_missing))

--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -295,6 +295,16 @@ namespace CEC {
 #define CEC_TDA995x_VIRTUAL_COM		"CuBox"
 
 /*!
+ * the path to use for the Exynos HDMI CEC device
+ */
+#define CEC_EXYNOS_PATH		"/dev/CEC"
+
+/*!
+ * the name of the virtual COM port to use for the EXYNOS' CEC wire
+ */
+#define CEC_EXYNOS_VIRTUAL_COM		"Exynos"
+
+/*!
  * Mimimum client version
  */
 #define CEC_MIN_LIB_VERSION          2
@@ -858,7 +868,8 @@ typedef enum cec_adapter_type
   ADAPTERTYPE_P8_EXTERNAL      = 0x1,
   ADAPTERTYPE_P8_DAUGHTERBOARD = 0x2,
   ADAPTERTYPE_RPI              = 0x100,
-  ADAPTERTYPE_TDA995x          = 0x200
+  ADAPTERTYPE_TDA995x          = 0x200,
+  ADAPTERTYPE_EXYNOS           = 0x300
 } cec_adapter_type;
 
 typedef struct cec_menu_language

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -59,5 +59,10 @@ libcec_la_SOURCES += adapter/TDA995x/TDA995xCECAdapterDetection.cpp \
                      adapter/TDA995x/TDA995xCECAdapterCommunication.cpp
 endif
 
+## Exynos support
+if USE_EXYNOS_API
+libcec_la_SOURCES += adapter/Exynos/ExynosCECAdapterDetection.cpp \
+                     adapter/Exynos/ExynosCECAdapterCommunication.cpp
+endif
 
 libcec_la_LDFLAGS = @LIBS_LIBCEC@ -version-info @VERSION@

--- a/src/lib/adapter/AdapterFactory.cpp
+++ b/src/lib/adapter/AdapterFactory.cpp
@@ -52,6 +52,11 @@
 #include "TDA995x/TDA995xCECAdapterCommunication.h"
 #endif
 
+#if defined(HAVE_EXYNOS_API)
+#include "Exynos/ExynosCECAdapterDetection.h"
+#include "Exynos/ExynosCECAdapterCommunication.h"
+#endif
+
 using namespace std;
 using namespace CEC;
 
@@ -109,6 +114,19 @@ int8_t CAdapterFactory::DetectAdapters(cec_adapter_descriptor *deviceList, uint8
   }
 #endif
 
+#if defined(HAVE_EXYNOS_API)
+  if (iAdaptersFound < iBufSize && CExynosCECAdapterDetection::FindAdapter())
+  {
+    snprintf(deviceList[iAdaptersFound].strComPath, sizeof(deviceList[iAdaptersFound].strComPath), CEC_EXYNOS_PATH);
+    snprintf(deviceList[iAdaptersFound].strComName, sizeof(deviceList[iAdaptersFound].strComName), CEC_EXYNOS_VIRTUAL_COM);
+    deviceList[iAdaptersFound].iVendorId = 0;
+    deviceList[iAdaptersFound].iProductId = 0;
+    deviceList[iAdaptersFound].adapterType = ADAPTERTYPE_EXYNOS;
+    iAdaptersFound++;
+  }
+#endif
+
+
 #if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API)
 #error "libCEC doesn't have support for any type of adapter. please check your build system or configuration"
 #endif
@@ -123,6 +141,11 @@ IAdapterCommunication *CAdapterFactory::GetInstance(const char *strPort, uint16_
     return new CTDA995xCECAdapterCommunication(m_lib->m_cec);
 #endif
 
+#if defined(HAVE_EXYNOS_API)
+  if (!strcmp(strPort, CEC_EXYNOS_VIRTUAL_COM))
+    return new CExynosCECAdapterCommunication(m_lib->m_cec);
+#endif
+
 #if defined(HAVE_RPI_API)
   if (!strcmp(strPort, CEC_RPI_VIRTUAL_COM))
     return new CRPiCECAdapterCommunication(m_lib->m_cec);
@@ -132,7 +155,7 @@ IAdapterCommunication *CAdapterFactory::GetInstance(const char *strPort, uint16_
   return new CUSBCECAdapterCommunication(m_lib->m_cec, strPort, iBaudRate);
 #endif
 
-#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API)
+#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API)
   return NULL;
 #endif
 }

--- a/src/lib/adapter/Exynos/ExynosCEC.h
+++ b/src/lib/adapter/Exynos/ExynosCEC.h
@@ -1,0 +1,39 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Exynos Code is Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+
+#define CEC_DEFAULT_PADDR   0x1000
+#define CEC_PADDR_NAME      "/sys/module/s5p_hdmi/parameters/source_phy_addr"
+#define CEC_IOC_SETLADDR    _IOW('c', 0, unsigned int)
+#define CEC_MAX_FRAME_SIZE  16

--- a/src/lib/adapter/Exynos/ExynosCECAdapterCommunication.cpp
+++ b/src/lib/adapter/Exynos/ExynosCECAdapterCommunication.cpp
@@ -1,0 +1,256 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Exynos Code is Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+
+#if defined(HAVE_EXYNOS_API)
+#include "ExynosCEC.h"
+#include "ExynosCECAdapterCommunication.h"
+
+#include "lib/CECTypeUtils.h"
+#include "lib/LibCEC.h"
+#include "lib/platform/util/StdString.h"
+#include "lib/platform/util/buffer.h"
+
+using namespace std;
+using namespace CEC;
+using namespace PLATFORM;
+
+#define LIB_CEC m_callback->GetLib()
+
+
+CExynosCECAdapterCommunication::CExynosCECAdapterCommunication(IAdapterCommunicationCallback *callback) :
+    IAdapterCommunication(callback),
+    m_bLogicalAddressChanged(false)
+{ 
+  CLockObject lock(m_mutex);
+
+  m_logicalAddresses.Clear();
+  m_fd = INVALID_SOCKET_VALUE;
+}
+
+
+CExynosCECAdapterCommunication::~CExynosCECAdapterCommunication(void)
+{
+  Close();
+}
+
+
+bool CExynosCECAdapterCommunication::IsOpen(void)
+{
+  return IsInitialised() && m_fd != INVALID_SOCKET_VALUE;
+}
+
+
+bool CExynosCECAdapterCommunication::Open(uint32_t UNUSED(iTimeoutMs), bool UNUSED(bSkipChecks), bool bStartListening)
+{
+  if (m_fd != INVALID_SOCKET_VALUE)
+    close(m_fd);
+
+  if ((m_fd = open(CEC_EXYNOS_PATH, O_RDWR)) > 0)
+  {
+    if (!bStartListening || CreateThread()) {
+        return true;
+    }
+    close(m_fd);
+  }
+  return false;
+}
+
+
+void CExynosCECAdapterCommunication::Close(void)
+{
+  StopThread(0);
+
+  close(m_fd);
+  m_fd = INVALID_SOCKET_VALUE;
+}
+
+
+std::string CExynosCECAdapterCommunication::GetError(void) const
+{
+  std::string strError(m_strError);
+  return strError;
+}
+
+
+cec_adapter_message_state CExynosCECAdapterCommunication::Write(
+  const cec_command &data, bool &UNUSED(bRetry), uint8_t UNUSED(iLineTimeout), bool UNUSED(bIsReply))
+{
+  uint8_t buffer[CEC_MAX_FRAME_SIZE];
+  int32_t size = 1;
+  cec_adapter_message_state rc = ADAPTER_MESSAGE_STATE_ERROR;
+
+  if (!IsOpen())
+    return rc;
+
+  if ((size_t)data.parameters.size + data.opcode_set > sizeof(buffer))
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: data size too large !", __func__);
+    return ADAPTER_MESSAGE_STATE_ERROR;
+  }
+ 
+  buffer[0] = (data.initiator << 4) | (data.destination & 0x0f);
+
+  if (data.opcode_set)
+  {
+    buffer[1] = data.opcode;
+    size++;
+
+    memcpy(&buffer[size], data.parameters.data, data.parameters.size);
+    size += data.parameters.size;
+  }
+
+  if (write(m_fd, (void *)buffer, size) == size)
+  {
+    rc = ADAPTER_MESSAGE_STATE_SENT_ACKED;
+  }
+  else
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: write failed !", __func__);
+  }
+
+  return rc;
+}
+
+
+uint16_t CExynosCECAdapterCommunication::GetFirmwareVersion(void)
+{
+  return 0;
+}
+
+
+cec_vendor_id CExynosCECAdapterCommunication::GetVendorId(void)
+{
+  return cec_vendor_id(CEC_VENDOR_SAMSUNG);
+}
+
+
+uint16_t CExynosCECAdapterCommunication::GetPhysicalAddress(void)
+{
+  uint16_t phys_addr = CEC_DEFAULT_PADDR;
+
+  FILE *f = fopen(CEC_PADDR_NAME, "r");
+  if(f) {
+    if(fscanf(f, "%hu", &phys_addr) != 1)
+      phys_addr = CEC_DEFAULT_PADDR;
+
+    fclose(f);
+  }
+  return phys_addr;
+}
+
+
+cec_logical_addresses CExynosCECAdapterCommunication::GetLogicalAddresses(void)
+{
+  return m_logicalAddresses;
+}
+
+
+bool CExynosCECAdapterCommunication::SetLogicalAddresses(const cec_logical_addresses &addresses)
+{
+  unsigned int log_addr = addresses.primary;
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return false;
+
+  if (ioctl(m_fd, CEC_IOC_SETLADDR, &log_addr))
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL SetLogicalAddr failed !", __func__);
+    return false;
+  }
+  m_logicalAddresses = addresses;
+  m_bLogicalAddressChanged = true;
+
+  return true;
+}
+
+
+void CExynosCECAdapterCommunication::HandleLogicalAddressLost(cec_logical_address UNUSED(oldAddress))
+{
+  unsigned int log_addr = CECDEVICE_BROADCAST;
+  if (ioctl(m_fd, CEC_IOC_SETLADDR, &log_addr))
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL SetLogicalAddr failed !", __func__);
+  }
+}
+
+
+void *CExynosCECAdapterCommunication::Process(void)
+{
+  uint8_t buffer[CEC_MAX_FRAME_SIZE];
+  uint32_t size;
+  fd_set rfds;
+  cec_logical_address initiator, destination;
+
+  if (!IsOpen())
+    return 0;
+
+  FD_ZERO(&rfds);
+  FD_SET(m_fd, &rfds);
+
+  while (!IsStopped())
+  {
+    if (select(m_fd + 1, &rfds, NULL, NULL, NULL) >= 0 )
+    {
+      size = read(m_fd, buffer, CEC_MAX_FRAME_SIZE);
+
+      if (size > 0)
+      {
+          initiator = cec_logical_address(buffer[0] >> 4);
+          destination = cec_logical_address(buffer[0] & 0x0f);
+
+          cec_command cmd;
+
+          cec_command::Format(
+            cmd, initiator, destination,
+            ( size > 1 ) ? cec_opcode(buffer[1]) : CEC_OPCODE_NONE);
+
+          for( uint8_t i = 2; i < size; i++ )
+            cmd.parameters.PushBack(buffer[i]);
+
+          if (!IsStopped())
+            m_callback->OnCommandReceived(cmd);
+      }
+    }
+
+  }
+
+  return 0;
+}
+
+#endif	// HAVE_EXYNOS_API

--- a/src/lib/adapter/Exynos/ExynosCECAdapterCommunication.h
+++ b/src/lib/adapter/Exynos/ExynosCECAdapterCommunication.h
@@ -1,0 +1,101 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Exynos Code is Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#if defined(HAVE_EXYNOS_API)
+
+#include "lib/platform/threads/mutex.h"
+#include "lib/platform/threads/threads.h"
+#include "lib/adapter/AdapterCommunication.h"
+#include <map>
+
+namespace CEC
+{
+  class CExynosCECAdapterCommunication : public IAdapterCommunication, public PLATFORM::CThread
+  {
+  public:
+    /*!
+     * @brief Create a new Exynos HDMI CEC communication handler.
+     * @param callback The callback to use for incoming CEC commands.
+     */
+    CExynosCECAdapterCommunication(IAdapterCommunicationCallback *callback);
+    virtual ~CExynosCECAdapterCommunication(void);
+
+    /** @name IAdapterCommunication implementation */
+    ///{
+    bool Open(uint32_t iTimeoutMs = CEC_DEFAULT_CONNECT_TIMEOUT, bool bSkipChecks = false, bool bStartListening = true);
+    void Close(void);
+    bool IsOpen(void);
+    std::string GetError(void) const;
+    cec_adapter_message_state Write(const cec_command &data, bool &bRetry, uint8_t iLineTimeout, bool bIsReply);
+
+    bool SetLineTimeout(uint8_t UNUSED(iTimeout)) { return true; }
+    bool StartBootloader(void) { return false; }
+    bool SetLogicalAddresses(const cec_logical_addresses &addresses);
+    cec_logical_addresses GetLogicalAddresses(void);
+    bool PingAdapter(void) { return IsInitialised(); }
+    uint16_t GetFirmwareVersion(void);
+    uint32_t GetFirmwareBuildDate(void) { return 0; }
+    bool IsRunningLatestFirmware(void) { return true; }
+    bool PersistConfiguration(const libcec_configuration & UNUSED(configuration)) { return false; }
+    bool GetConfiguration(libcec_configuration & UNUSED(configuration)) { return false; }
+    std::string GetPortName(void) { return std::string("EXYNOS"); }
+    uint16_t GetPhysicalAddress(void);
+    bool SetControlledMode(bool UNUSED(controlled)) { return true; }
+    cec_vendor_id GetVendorId(void);
+    bool SupportsSourceLogicalAddress(const cec_logical_address address) { return address > CECDEVICE_TV && address <= CECDEVICE_BROADCAST; }
+    cec_adapter_type GetAdapterType(void) { return ADAPTERTYPE_EXYNOS; }
+    uint16_t GetAdapterVendorId(void) const { return 1; }
+    uint16_t GetAdapterProductId(void) const { return 1; }
+    void HandleLogicalAddressLost(cec_logical_address oldAddress);
+    void SetActiveSource(bool UNUSED(bSetTo), bool UNUSED(bClientUnregistered)) {}
+    ///}
+
+    /** @name PLATFORM::CThread implementation */
+    ///{
+    void *Process(void);
+    ///}
+
+  private:
+    bool IsInitialised(void) const { return 1; };
+
+    std::string                 m_strError; /**< current error message */
+
+    bool                        m_bLogicalAddressChanged;
+    cec_logical_addresses       m_logicalAddresses;
+
+    PLATFORM::CMutex            m_mutex;
+    int                         m_fd;
+  };
+};
+#endif

--- a/src/lib/adapter/Exynos/ExynosCECAdapterDetection.cpp
+++ b/src/lib/adapter/Exynos/ExynosCECAdapterDetection.cpp
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Exynos Code is Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+#include <stdio.h>
+
+#if defined(HAVE_EXYNOS_API)
+#include "ExynosCECAdapterDetection.h"
+#include "ExynosCEC.h"
+
+using namespace CEC;
+
+bool CExynosCECAdapterDetection::FindAdapter(void)
+{
+  return access(CEC_EXYNOS_PATH, 0) == 0;
+}
+
+#endif

--- a/src/lib/adapter/Exynos/ExynosCECAdapterDetection.h
+++ b/src/lib/adapter/Exynos/ExynosCECAdapterDetection.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Exynos Code is Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+namespace CEC
+{
+  class CExynosCECAdapterDetection
+  {
+  public:
+    static bool FindAdapter(void);
+  };
+}


### PR DESCRIPTION
This pull request adds support for Exynos based chips. Currently it has been tested on the HTPC boards provided by Hardkernel http://www.hardkernel.com/main/main.php but it most likely works with other devices too.

The driver is quite simple, the device provides raw access to the CEC bus via the /dev/CEC device node. One can write raw CEC frames to /dev/CEC and also read/poll the it for incoming data. There is no ACK mechanism but a write will fail if a non-existant logical address is used.
