### PR TITLE
Added missing const for cec_set_configuration argument

### DIFF
--- a/src/lib/LibCECC.cpp
+++ b/src/lib/LibCECC.cpp
@@ -346,7 +346,7 @@ int cec_persist_configuration(libcec_configuration *configuration)
   return cec_parser ? (cec_parser->PersistConfiguration(configuration) ? 1 : 0) : -1;
 }
 
-int cec_set_configuration(libcec_configuration *configuration)
+int cec_set_configuration(const libcec_configuration *configuration)
 {
   return cec_parser ? (cec_parser->SetConfiguration(configuration) ? 1 : 0) : -1;
 }


### PR DESCRIPTION
Method now matches prototype and is correctly exported for C. Fixes #26
