### PR TITLE
Fix CCECCommandHandler::HasSpecificHandler

### DIFF
--- a/src/lib/implementations/CECCommandHandler.h
+++ b/src/lib/implementations/CECCommandHandler.h
@@ -58,7 +58,7 @@ namespace CEC
     virtual bool HandleCommand(const cec_command &command);
     virtual cec_vendor_id GetVendorId(void) { return m_vendorId; };
     virtual void SetVendorId(cec_vendor_id vendorId) { m_vendorId = vendorId; }
-    static bool HasSpecificHandler(cec_vendor_id vendorId) { return vendorId == CEC_VENDOR_LG || vendorId == CEC_VENDOR_SAMSUNG || vendorId == CEC_VENDOR_PANASONIC || vendorId == CEC_VENDOR_PHILIPS || vendorId == CEC_VENDOR_SHARP;}
+    static bool HasSpecificHandler(cec_vendor_id vendorId) { return vendorId == CEC_VENDOR_LG || vendorId == CEC_VENDOR_SAMSUNG || vendorId == CEC_VENDOR_PANASONIC || vendorId == CEC_VENDOR_PHILIPS || vendorId == CEC_VENDOR_SHARP || vendorId == CEC_VENDOR_TOSHIBA || vendorId == CEC_VENDOR_TOSHIBA2 || vendorId == CEC_VENDOR_ONKYO;}
 
     virtual bool InitHandler(void) { return true; }
     virtual bool ActivateSource(bool bTransmitDelayedCommandsOnly = false);


### PR DESCRIPTION
There are specific command handlers for Toshiba and Onkyo (see CCECBusDevice::ReplaceHandler(...)), but CCECCommandHandler::HasSpecificHandler(...) did not include vendor TOSHIBA, TOSHIBA2, ONKYO. Result was, that the specific handlers for Toshiba and Onkyo never got instantiated.
