### PR TITLE
Revert cec_set_configuration() to take non-const parameter to keep old ABI

### DIFF
--- a/src/lib/LibCECC.cpp
+++ b/src/lib/LibCECC.cpp
@@ -346,6 +346,11 @@ int cec_persist_configuration(libcec_configuration *configuration)
   return cec_parser ? (cec_parser->PersistConfiguration(configuration) ? 1 : 0) : -1;
 }
 
+int cec_set_configuration(libcec_configuration *configuration)
+{
+  return cec_set_configuration(static_cast<const libcec_configuration*>(configuration));
+}
+
 int cec_set_configuration(const libcec_configuration *configuration)
 {
   return cec_parser ? (cec_parser->SetConfiguration(configuration) ? 1 : 0) : -1;


### PR DESCRIPTION
Changing constness changed the mangled name of the function thus broke C++ ABI exported by the library.
Since the major version has not been bumped I assume this was not intentional.
