### PR TITLE
[posix] - we need to obey the pthread func prototype - void * might not ...

### DIFF
--- a/src/lib/platform/threads/threads.h
+++ b/src/lib/platform/threads/threads.h
@@ -52,8 +52,9 @@ namespace PLATFORM
         if (ThreadsWait(m_thread, &retVal)){}; // silence unused warning
     }
 
-    static void *ThreadHandler(CThread *thread)
+    static void *ThreadHandler(void *_thread)
     {
+      CThread *thread = static_cast<CThread *>(_thread);
       void *retVal = NULL;
 
       if (thread)


### PR DESCRIPTION
...be

the same as a class pointer. This should fix deadhang on CreateThreads on
some darwin runtimes and maybe other posix platforms.

Backport from pvr addons:
https://github.com/opdenkamp/xbmc-pvr-addons/pull/378
