### PR TITLE
Fix compilation on Raspberry Pi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,7 @@ case "${host}" in
 #endif]], [[]])],[AC_MSG_RESULT([yes])],[check_rpi_cec_service="no"; AC_MSG_RESULT([no])])
 
       ## check if the methods we're using can be found in libbcm_host.so, so we don't use an incompatible version
-      AC_CHECK_LIB(bcm_host,vchi_initialise,,check_rpi_cec_service="no")
+      AC_CHECK_LIB(bcm_host,vchi_initialise,,[AC_CHECK_LIB(vchiq_arm,vchi_initialise,,check_rpi_cec_service="no")])
       libs_tmp="$LIBS"
       AC_CHECK_LIB(bcm_host,vc_vchi_cec_init,,check_rpi_cec_service="no")
       AC_CHECK_LIB(bcm_host,vc_cec_get_logical_address,,check_rpi_cec_service="no")
@@ -201,7 +201,7 @@ case "${host}" in
       AC_CHECK_LIB(bcm_host,vc_cec_set_passive,,check_rpi_cec_service="no")
       AC_CHECK_LIB(bcm_host,vcos_init,,check_rpi_cec_service="no")
       AC_CHECK_LIB(bcm_host,vchiq_initialise,,check_rpi_cec_service="no")
-      AC_CHECK_LIB(bcm_host,vchi_initialise,,check_rpi_cec_service="no")
+      AC_CHECK_LIB(bcm_host,vchi_initialise,,[AC_CHECK_LIB(vchiq_arm,vchi_initialise,,check_rpi_cec_service="no")])
       AC_CHECK_LIB(bcm_host,vchi_create_connection,,check_rpi_cec_service="no")
       AC_CHECK_LIB(bcm_host,bcm_host_init,,check_rpi_cec_service="no")
       LIBS="$libs_tmp"

--- a/configure.ac
+++ b/configure.ac
@@ -168,7 +168,7 @@ case "${host}" in
     if test "x$use_rpi" != "xno"; then
       CPPFLAGS="$CPPFLAGS $RPI_CFLAGS"
       libs_pre_rpi="$LIBS"
-      LIBS="$LIBS $RPI_LIBS -lvcos -lvchiq_arm"
+      LIBS="$LIBS $RPI_LIBS -lvcos -lvchiq_arm -lbcm_host"
 
       check_rpi_cec_service="yes"
 


### PR DESCRIPTION
vchi_initialise has been moved from libbcm_host to libvchiq_arm, so try both.

Patched configure output:
checking for vchi_initialise in -lbcm_host... no
checking for vchi_initialise in -lvchiq_arm... yes


$ cec-client -l
Found devices: 1

device:              1
com port:            RPI
vendor id:           2708
product id:          1001
firmware version:    1
type:                Raspberry Pi
