### PR TITLE
Add a way with drm files to autodetect physical ID

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -341,6 +341,8 @@ AC_CHECK_HEADER(netinet/tcp.h,,AC_MSG_ERROR($msg_required_header_missing))
 AC_CHECK_HEADER(sys/socket.h,,AC_MSG_ERROR($msg_required_header_missing))
 AC_CHECK_HEADER(sys/time.h,,AC_MSG_ERROR($msg_required_header_missing))
 AC_CHECK_HEADER(sys/types.h,,AC_MSG_ERROR($msg_required_header_missing))
+AC_CHECK_HEADER(dirent.h,,AC_MSG_ERROR($msg_required_header_missing))
+AC_CHECK_HEADER(fstream,,AC_MSG_ERROR($msg_required_header_missing))
 AC_CHECK_FUNCS([close fcntl select write read shutdown send recv memset sprintf getaddrinfo getsockopt setsockopt connect poll sched_yield open strerror tcsetattr tcgetattr cfsetispeed cfsetospeed bind freeaddrinfo listen accept socket])
 
 ## add the build date to LIB_INFO

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -43,7 +43,8 @@ libcec_la_SOURCES += adapter/Pulse-Eight/USBCECAdapterMessage.cpp \
                      platform/posix/serialport.cpp \
                      platform/posix/os-edid.cpp \
                      platform/adl/adl-edid.cpp \
-                     platform/nvidia/nv-edid.cpp
+                     platform/nvidia/nv-edid.cpp \
+                     platform/drm/drm-edid.cpp
 if USE_X11_RANDR
 libcec_la_SOURCES += platform/X11/randr-edid.cpp
 endif

--- a/src/lib/adapter/Pulse-Eight/USBCECAdapterCommunication.cpp
+++ b/src/lib/adapter/Pulse-Eight/USBCECAdapterCommunication.cpp
@@ -43,6 +43,7 @@
 #include "lib/platform/util/edid.h"
 #include "lib/platform/adl/adl-edid.h"
 #include "lib/platform/nvidia/nv-edid.h"
+#include "lib/platform/drm/drm-edid.h"
 #include "lib/LibCEC.h"
 #include "lib/CECProcessor.h"
 
@@ -686,6 +687,18 @@ uint16_t CUSBCECAdapterCommunication::GetPhysicalAddress(void)
     LIB_CEC->AddLog(CEC_LOG_DEBUG, "%s - nvidia driver returned physical address %04x", __FUNCTION__, iPA);
   }
 #endif
+
+// try to get the PA from the intel driver
+#if defined(HAS_DRM_EDID_PARSER)
+  if (iPA == 0)
+  {
+    LIB_CEC->AddLog(CEC_LOG_DEBUG, "%s - trying to get the physical address via drm files", __FUNCTION__);
+    CDRMEdidParser nv;
+    iPA = nv.GetPhysicalAddress();
+    LIB_CEC->AddLog(CEC_LOG_DEBUG, "%s - drm files returned physical address %04x", __FUNCTION__, iPA);
+  }
+#endif
+ 
 
   // try to get the PA from the OS
   if (iPA == 0)

--- a/src/lib/platform/drm/drm-edid.cpp
+++ b/src/lib/platform/drm/drm-edid.cpp
@@ -1,0 +1,120 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+
+#include "lib/platform/os.h"
+#include "drm-edid.h"
+
+using namespace PLATFORM;
+
+uint16_t CDRMEdidParser::GetPhysicalAddress(void)
+{
+  uint16_t iPA(0);
+
+  #if !defined(__WINDOWS__)
+
+  // Fisrt we look for all DRM subfolder
+  std::string baseDir = "/sys/class/drm/";
+ 
+  DIR *dir = opendir(baseDir.c_str());
+
+  struct dirent *entry = readdir(dir);
+  std::string enablededid;
+  std::string line;
+
+  while (entry != NULL)
+  {
+    // We look if the element is a symlinl
+    if (entry->d_type == DT_LNK)
+    {
+      // We look for the file enable to find the active video card
+      std::string path, enabledPath, edidPath;
+      path = baseDir + entry->d_name;
+      enabledPath = path + "/enabled"; 
+      edidPath = path + "/edid";
+      
+      std::ifstream f(enabledPath.c_str());
+      if (f.is_open()) 
+      {
+        if (f.good() && !f.eof())
+        {
+          getline(f, line);
+          
+          // We look if the card is "Enabled"
+          if (line == "enabled")
+          {
+            // We look if the directory have an edid file
+            std::ifstream edid(edidPath.c_str());
+            if (edid.is_open()) 
+            {
+              if (edid.good()) {
+                enablededid = edidPath;
+              }
+              edid.close();
+            }
+          }
+        }
+        f.close();
+      }
+    }
+    entry = readdir(dir);
+  }
+
+  closedir(dir);
+
+  if (!enablededid.empty())
+  {
+    FILE *fp = fopen(enablededid.c_str(), "r");
+  
+    if (fp)
+    {
+      char buf[4096];
+      memset(buf, 0, sizeof(buf));
+      int iPtr(0);
+      int c(0);
+      while (c != EOF)
+      {
+        c = fgetc(fp);
+        if (c != EOF)
+          buf[iPtr++] = c;
+      }
+  
+      iPA = CEDIDParser::GetPhysicalAddressFromEDID(buf, iPtr);
+      fclose(fp);
+    }
+  }
+
+  #endif
+
+  return iPA;
+}

--- a/src/lib/platform/drm/drm-edid.h
+++ b/src/lib/platform/drm/drm-edid.h
@@ -1,0 +1,48 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#define HAS_DRM_EDID_PARSER
+
+#include "lib/platform/util/edid.h"
+
+namespace PLATFORM
+{
+  class CDRMEdidParser
+  {
+    public:
+      CDRMEdidParser(void) {};
+      virtual ~CDRMEdidParser(void) {};
+
+      uint16_t GetPhysicalAddress(void);
+  };
+}

--- a/src/lib/platform/posix/os-types.h
+++ b/src/lib/platform/posix/os-types.h
@@ -44,6 +44,8 @@
 #include <poll.h>
 #include <semaphore.h>
 #include <stdint.h>
+#include <dirent.h>
+#include <fstream>
 
 #include <inttypes.h>
 #include <stdint.h>


### PR DESCRIPTION
Hi, 
This is the proper version of pull request #34 (Sorry, for the 2 pull request, i reseted my repository to start over with the latest changes)

So as you requested : 
* I renamed it to drm-edid
* 2 spaces padding
* use of .empty()
* nested if : i keep certain to properly close handle
* fread : tried, but always fail (I can read other file, but not the edid file)
* CLA : ok as of 27/07/2014

Feel free to comment,

Steve