### PR TITLE
Add the Google CEC Vendor ID

### DIFF
--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -850,6 +850,7 @@ typedef enum cec_vendor_id
   CEC_VENDOR_TOSHIBA2       = 0x000CE7,
   CEC_VENDOR_PULSE_EIGHT    = 0x001582,
   CEC_VENDOR_HARMAN_KARDON2 = 0x001950,
+  CEC_VENDOR_GOOGLE         = 0x001A11,
   CEC_VENDOR_AKAI           = 0x0020C7,
   CEC_VENDOR_AOC            = 0x002467,
   CEC_VENDOR_PANASONIC      = 0x008045,
@@ -865,7 +866,6 @@ typedef enum cec_vendor_id
   CEC_VENDOR_VIZIO          = 0x6B746D,
   CEC_VENDOR_BENQ           = 0x8065E9,
   CEC_VENDOR_HARMAN_KARDON  = 0x9C645E,
-  CEC_VENDOR_GOOGLE         = 0x001A11,
   CEC_VENDOR_UNKNOWN        = 0
 } cec_vendor_id;
 

--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -865,6 +865,7 @@ typedef enum cec_vendor_id
   CEC_VENDOR_VIZIO          = 0x6B746D,
   CEC_VENDOR_BENQ           = 0x8065E9,
   CEC_VENDOR_HARMAN_KARDON  = 0x9C645E,
+  CEC_VENDOR_GOOGLE         = 0x001A11,
   CEC_VENDOR_UNKNOWN        = 0
 } cec_vendor_id;
 

--- a/src/LibCecSharp/CecSharpTypes.h
+++ b/src/LibCecSharp/CecSharpTypes.h
@@ -794,6 +794,7 @@ namespace CecSharp
     Toshiba2      = 0x000CE7,
     PulseEight    = 0x001582,
     HarmanKardon2 = 0x001950,
+    Google        = 0x001A11,
     Akai          = 0x0020C7,
     AOC           = 0x002467,
     Panasonic     = 0x008045,
@@ -809,7 +810,6 @@ namespace CecSharp
     Vizio         = 0x6B746D,
     Benq          = 0x8065E9,
     HarmanKardon  = 0x9C645E,
-    Google	  = 0x001A11,
     Unknown       = 0
   };
 

--- a/src/LibCecSharp/CecSharpTypes.h
+++ b/src/LibCecSharp/CecSharpTypes.h
@@ -809,6 +809,7 @@ namespace CecSharp
     Vizio         = 0x6B746D,
     Benq          = 0x8065E9,
     HarmanKardon  = 0x9C645E,
+    Google	  = 0x001A11,
     Unknown       = 0
   };
 

--- a/src/libcec/CECTypeUtils.h
+++ b/src/libcec/CECTypeUtils.h
@@ -526,6 +526,8 @@ namespace CEC
         return "Harman/Kardon";
       case CEC_VENDOR_PULSE_EIGHT:
         return "Pulse Eight";
+      case CEC_VENDOR_GOOGLE:
+        return "Google";
       default:
         return "Unknown";
       }


### PR DESCRIPTION
I did some sniffing around and found that `001a11` is the Google CEC Vendor ID, at least the one that my (and quite a few others) Chromecast reports.

Funny fact, as I was looking around to confirm that was the correct vendor ID, I stumbled upon the fact that [Google owns `001a11` as a MAC Address prefix](http://www.coffer.com/mac_find/?string=google) as well as the CEC Vendor ID. Quite the coincidence huh? 