### PR TITLE
(re)Added vc_cec_poll_address for sole purpose of LA neg. process

### DIFF
--- a/src/libcec/adapter/RPi/RPiCECAdapterCommunication.h
+++ b/src/libcec/adapter/RPi/RPiCECAdapterCommunication.h
@@ -100,6 +100,7 @@ namespace CEC
     bool UnregisterLogicalAddress(void);
     bool RegisterLogicalAddress(const cec_logical_address address, uint32_t iTimeoutMs = CEC_DEFAULT_CONNECT_TIMEOUT);
     int InitHostCEC(void);
+    void SetDisableCallback(const bool disable);
 
     bool m_bInitialised;   /**< true when the connection is initialised, false otherwise */
     std::string m_strError; /**< current error message */
@@ -113,6 +114,8 @@ namespace CEC
     VCHI_CONNECTION_T *         m_vchi_connection;
     cec_logical_address         m_previousLogicalAddress;
     bool                        m_bLogicalAddressRegistered;
+
+    bool                        m_bDisableCallbacks;
   };
 };
 


### PR DESCRIPTION
@opdenkamp 

on the past RPI rewrite I abandoned the vc_cec_poll_address (that's the only way to force RPI to generate msg with same dest and origin address) usage due to it's "do-it-all" nature which was complicating the plain&simple 'adapter' (as libCEC's endpoint) approach. empty A->B messages served for this purpose well until I recently found there are devices and situations where this is breaking LA neg process completely and RPI registers a dup address with all the nasty consequences to follow.

such case is IMX6 adapter at one specific internal state of his - a moment at msg receiving when the receiving msg is only being written to internal buffer (so receiving is not yet finished). at this point, IMX6's firmware is NACKing ALL incoming messages but the POLLing (X->X). and because RPI is sending regular message (A->B) it gets NACK in return resulting in false premise of this LA being free.

generally the probability to hit IMX6-like device and hit it at the msg receiving process (taking only few millis) is very much lucky, but still.
so here is a fix with a re-implementation of vc_cec_poll_address. 
there are extended comments at the changed lines - feel free to remove them after merge - it is (mostly) for @popcornmix and you to get idea.

the patch is used for few weeks already by XBian and @popcornmix in newclock4. 

br,
mk
