### PR TITLE
Add support for configurable button repeats with libcec

### DIFF
--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -1493,6 +1493,8 @@ struct libcec_configuration
                                                    XXX changed meaning in 2.2.0 to not break binary compatibility. next major (3.0) release will fix it in a nicer way */
   cec_user_control_code comboKey;             /*!< key code that initiates combo keys. defaults to CEC_USER_CONTROL_CODE_F1_BLUE. CEC_USER_CONTROL_CODE_UNKNOWN to disable. added in 2.0.5 */
   uint32_t              iComboKeyTimeoutMs;   /*!< timeout until the combo key is sent as normal keypress */
+  uint32_t              iButtonRepeatRateMs;  /*!< rate at which buttons autorepeat. 0 means rely on CEC device */
+  uint32_t              iButtonReleaseDelayMs;/*!< duration after last update until a button is considered released */
 
 #ifdef __cplusplus
    libcec_configuration(void) { Clear(); }
@@ -1527,6 +1529,8 @@ struct libcec_configuration
                  cecVersion                == other.cecVersion &&
                  adapterType               == other.adapterType &&
                  iDoubleTapTimeout50Ms     == other.iDoubleTapTimeout50Ms &&
+                 iButtonRepeatRateMs       == other.iButtonRepeatRateMs &&
+                 iButtonReleaseDelayMs     == other.iButtonReleaseDelayMs &&
                  (other.clientVersion <= LIBCEC_VERSION_TO_UINT(2, 0, 4) || comboKey            == other.comboKey) &&
                  (other.clientVersion <= LIBCEC_VERSION_TO_UINT(2, 0, 4) || iComboKeyTimeoutMs  == other.iComboKeyTimeoutMs) &&
                  (other.clientVersion <  LIBCEC_VERSION_TO_UINT(2, 1, 0) || bPowerOnScreensaver == other.bPowerOnScreensaver));
@@ -1567,6 +1571,8 @@ struct libcec_configuration
     iDoubleTapTimeout50Ms =           CEC_DOUBLE_TAP_TIMEOUT_50_MS;
     comboKey =                        CEC_USER_CONTROL_CODE_STOP;
     iComboKeyTimeoutMs =              CEC_DEFAULT_COMBO_TIMEOUT_MS;
+    iButtonRepeatRateMs =             0;
+    iButtonReleaseDelayMs =           CEC_BUTTON_TIMEOUT;
 
     memset(strDeviceName, 0, 13);
     deviceTypes.Clear();

--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -60,11 +60,8 @@ CCECClient::CCECClient(CCECProcessor *processor, const libcec_configuration &con
     m_releaseButtontime(0),
     m_pressedButtoncount(0),
     m_releasedButtoncount(0),
-    m_iPreventForwardingPowerOffCommand(0),
-    m_iLastKeypressTime(0)
+    m_iPreventForwardingPowerOffCommand(0)
 {
-  m_lastKeypress.keycode = CEC_USER_CONTROL_CODE_UNKNOWN;
-  m_lastKeypress.duration = 0;
   m_configuration.Clear();
   // set the initial configuration
   SetConfiguration(configuration);
@@ -1652,20 +1649,7 @@ void CCECClient::CallbackAddKey(const cec_keypress &key)
 {
   CLockObject lock(m_cbMutex);
   if (m_configuration.callbacks && m_configuration.callbacks->CBCecKeyPress)
-  {
-    // prevent double taps
-    int64_t now = GetTimeMs();
-    if (m_lastKeypress.keycode != key.keycode ||
-        key.duration > 0 ||
-        now - m_iLastKeypressTime >= DoubleTapTimeoutMS())
-    {
-      // no double tap
-      if (key.duration == 0)
-        m_iLastKeypressTime = now;
-      m_lastKeypress = key;
       m_configuration.callbacks->CBCecKeyPress(m_configuration.callbackParam, key);
-    }
-  }
 }
 
 void CCECClient::CallbackAddLog(const cec_log_message &message)

--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -986,10 +986,6 @@ void CCECClient::AddKey(bool bSendComboKey /* = false */, bool bButtonRelease /*
   cec_keypress key;
   key.keycode = CEC_USER_CONTROL_CODE_UNKNOWN;
 
-  // we ignore button releases when supporting repeating keys
-  if (bButtonRelease && m_configuration.iButtonRepeatRateMs && m_configuration.iButtonReleaseDelayMs)
-    return;
-
   {
     CLockObject lock(m_mutex);
     if (m_iCurrentButton != CEC_USER_CONTROL_CODE_UNKNOWN)
@@ -1014,6 +1010,10 @@ void CCECClient::AddKey(bool bSendComboKey /* = false */, bool bButtonRelease /*
       }
     }
   }
+
+  // we don't forward releases when supporting repeating keys
+  if (bButtonRelease && m_configuration.iButtonRepeatRateMs)
+    return;
 
   if (key.keycode != CEC_USER_CONTROL_CODE_UNKNOWN)
   {
@@ -1107,7 +1107,7 @@ void CCECClient::AddKey(const cec_keypress &key)
 
   if (!isrepeat && (key.keycode != comboKey || key.duration > 0))
   {
-    LIB_CEC->AddLog(CEC_LOG_DEBUG, "key pressed: %s (%1x)", ToString(transmitKey.keycode), transmitKey.keycode);
+    LIB_CEC->AddLog(CEC_LOG_DEBUG, "key pressed: %s (%1x, %d)", ToString(transmitKey.keycode), transmitKey.keycode, transmitKey.duration);
     QueueAddKey(transmitKey);
   }
 }
@@ -1129,6 +1129,7 @@ uint16_t CCECClient::CheckKeypressTimeout(void)
   unsigned int timeout = CEC_PROCESSOR_SIGNAL_WAIT_TIME;
   cec_keypress key;
   key.keycode = CEC_USER_CONTROL_CODE_UNKNOWN;
+  key.duration = 0;
 
   if (m_iCurrentButton == CEC_USER_CONTROL_CODE_UNKNOWN)
     return timeout;
@@ -1141,8 +1142,7 @@ uint16_t CCECClient::CheckKeypressTimeout(void)
     uint32_t iTimeoutMs(m_configuration.clientVersion >= LIBCEC_VERSION_TO_UINT(2, 0, 5) ?
         m_configuration.iComboKeyTimeoutMs : CEC_DEFAULT_COMBO_TIMEOUT_MS);
 
-    if ((m_iCurrentButton == comboKey && iTimeoutMs > 0 && iNow - m_updateButtontime >= iTimeoutMs) ||
-          (m_iCurrentButton != comboKey && m_releaseButtontime && iNow >= (uint64_t)m_releaseButtontime))
+    if (m_iCurrentButton == comboKey && iTimeoutMs > 0 && iNow - m_updateButtontime >= iTimeoutMs)
     {
       key.duration = (unsigned int) (iNow - m_initialButtontime);
       key.keycode = m_iCurrentButton;
@@ -1155,9 +1155,22 @@ uint16_t CCECClient::CheckKeypressTimeout(void)
       m_pressedButtoncount = 0;
       m_releasedButtoncount = 0;
     }
+    else if (m_iCurrentButton != comboKey && m_releaseButtontime && iNow >= (uint64_t)m_releaseButtontime)
+    {
+      key.duration = (unsigned int) (iNow - m_initialButtontime);
+      key.keycode = CEC_USER_CONTROL_CODE_UNKNOWN;
+
+      m_iCurrentButton = CEC_USER_CONTROL_CODE_UNKNOWN;
+      m_initialButtontime = 0;
+      m_updateButtontime = 0;
+      m_repeatButtontime = 0;
+      m_releaseButtontime = 0;
+      m_pressedButtoncount = 0;
+      m_releasedButtoncount = 0;
+    }
     else if (m_iCurrentButton != comboKey && m_repeatButtontime && iNow >= (uint64_t)m_repeatButtontime)
     {
-      key.duration = 0;
+      key.duration = (unsigned int) (iNow - m_initialButtontime);
       key.keycode = m_iCurrentButton;
       m_repeatButtontime = iNow + m_configuration.iButtonRepeatRateMs;
       timeout = std::min((uint64_t)timeout, m_repeatButtontime - iNow);
@@ -1176,8 +1189,8 @@ uint16_t CCECClient::CheckKeypressTimeout(void)
         timeout = CEC_PROCESSOR_SIGNAL_WAIT_TIME;
       }
     }
-    LIB_CEC->AddLog(CEC_LOG_DEBUG, "key %s: %s (%1x) timeout:%dms (rel:%d,rep:%d,prs:%d,rel:%d)", key.keycode == CEC_USER_CONTROL_CODE_UNKNOWN ? "idle" : key.duration ? "released" : "repeated",
-        ToString(m_iCurrentButton), m_iCurrentButton, timeout, (int)(m_releaseButtontime ? m_releaseButtontime - iNow : 0), (int)(m_repeatButtontime ? m_repeatButtontime - iNow : 0), m_pressedButtoncount, m_releasedButtoncount);
+    LIB_CEC->AddLog(CEC_LOG_DEBUG, "Key %s: %s (duration:%d) (%1x) timeout:%dms (rel:%d,rep:%d,prs:%d,rel:%d)", ToString(m_iCurrentButton), key.keycode == CEC_USER_CONTROL_CODE_UNKNOWN ? "idle" : m_repeatButtontime ? "repeated" : "released", key.duration,
+        m_iCurrentButton, timeout, (int)(m_releaseButtontime ? m_releaseButtontime - iNow : 0), (int)(m_repeatButtontime ? m_repeatButtontime - iNow : 0), m_pressedButtoncount, m_releasedButtoncount);
   }
 
   if (key.keycode != CEC_USER_CONTROL_CODE_UNKNOWN)

--- a/src/libcec/CECClient.h
+++ b/src/libcec/CECClient.h
@@ -450,8 +450,6 @@ namespace CEC
     int32_t               m_pressedButtoncount;                /**< the number of times a button released message has been seen for this press. */
     int32_t               m_releasedButtoncount;               /**< the number of times a button pressed message has been seen for this press. */
     int64_t               m_iPreventForwardingPowerOffCommand; /**< prevent forwarding standby commands until this time */
-    int64_t               m_iLastKeypressTime;                 /**< last time a key press was sent to the client */
-    cec_keypress          m_lastKeypress;                      /**< the last key press that was sent to the client */
     PLATFORM::SyncedBuffer<CCallbackWrap*> m_callbackCalls;
   };
 }

--- a/src/libcec/CECClient.h
+++ b/src/libcec/CECClient.h
@@ -308,7 +308,7 @@ namespace CEC
     // callbacks
     virtual void                  Alert(const libcec_alert type, const libcec_parameter &param) { QueueAlert(type, param); }
     virtual void                  AddLog(const cec_log_message &message) { QueueAddLog(message); }
-    virtual void                  AddKey(bool bSendComboKey = false);
+    virtual void                  AddKey(bool bSendComboKey = false, bool bButtonRelease = false);
     virtual void                  AddKey(const cec_keypress &key);
     virtual void                  SetCurrentButton(const cec_user_control_code iButtonCode);
     virtual uint16_t              CheckKeypressTimeout(void);
@@ -445,6 +445,10 @@ namespace CEC
     cec_user_control_code m_iCurrentButton;                    /**< the control code of the button that's currently held down (if any) */
     int64_t               m_initialButtontime;                 /**< the timestamp when the button was initially pressed (in seconds since epoch), or 0 if none was pressed. */
     int64_t               m_updateButtontime;                  /**< the timestamp when the button was updated (in seconds since epoch), or 0 if none was pressed. */
+    int64_t               m_repeatButtontime;                  /**< the timestamp when the button will next repeat (in seconds since epoch), or 0 if repeat is disabled. */
+    int64_t               m_releaseButtontime;                 /**< the timestamp when the button will be released (in seconds since epoch), or 0 if none was pressed. */
+    int32_t               m_pressedButtoncount;                /**< the number of times a button released message has been seen for this press. */
+    int32_t               m_releasedButtoncount;               /**< the number of times a button pressed message has been seen for this press. */
     int64_t               m_iPreventForwardingPowerOffCommand; /**< prevent forwarding standby commands until this time */
     int64_t               m_iLastKeypressTime;                 /**< last time a key press was sent to the client */
     cec_keypress          m_lastKeypress;                      /**< the last key press that was sent to the client */

--- a/src/libcec/CECClient.h
+++ b/src/libcec/CECClient.h
@@ -311,7 +311,7 @@ namespace CEC
     virtual void                  AddKey(bool bSendComboKey = false);
     virtual void                  AddKey(const cec_keypress &key);
     virtual void                  SetCurrentButton(const cec_user_control_code iButtonCode);
-    virtual void                  CheckKeypressTimeout(void);
+    virtual uint16_t              CheckKeypressTimeout(void);
     virtual void                  SourceActivated(const cec_logical_address logicalAddress);
     virtual void                  SourceDeactivated(const cec_logical_address logicalAddress);
 

--- a/src/libcec/CECClient.h
+++ b/src/libcec/CECClient.h
@@ -443,7 +443,8 @@ namespace CEC
     PLATFORM::CMutex      m_mutex;                             /**< mutex for changes to this instance */
     PLATFORM::CMutex      m_cbMutex;                           /**< mutex that is held when doing anything with callbacks */
     cec_user_control_code m_iCurrentButton;                    /**< the control code of the button that's currently held down (if any) */
-    int64_t               m_buttontime;                        /**< the timestamp when the button was pressed (in seconds since epoch), or 0 if none was pressed. */
+    int64_t               m_initialButtontime;                 /**< the timestamp when the button was initially pressed (in seconds since epoch), or 0 if none was pressed. */
+    int64_t               m_updateButtontime;                  /**< the timestamp when the button was updated (in seconds since epoch), or 0 if none was pressed. */
     int64_t               m_iPreventForwardingPowerOffCommand; /**< prevent forwarding standby commands until this time */
     int64_t               m_iLastKeypressTime;                 /**< last time a key press was sent to the client */
     cec_keypress          m_lastKeypress;                      /**< the last key press that was sent to the client */

--- a/src/libcec/CECProcessor.cpp
+++ b/src/libcec/CECProcessor.cpp
@@ -52,7 +52,6 @@
 using namespace CEC;
 using namespace PLATFORM;
 
-#define CEC_PROCESSOR_SIGNAL_WAIT_TIME 1000
 #define ACTIVE_SOURCE_CHECK_INTERVAL   500
 #define TV_PRESENT_CHECK_INTERVAL      30000
 
@@ -260,6 +259,7 @@ bool CCECProcessor::OnCommandReceived(const cec_command &command)
 
 void *CCECProcessor::Process(void)
 {
+  uint16_t timeout = CEC_PROCESSOR_SIGNAL_WAIT_TIME;
   m_libcec->AddLog(CEC_LOG_DEBUG, "processor thread started");
 
   if (!m_connCheck)
@@ -274,13 +274,13 @@ void *CCECProcessor::Process(void)
   while (!IsStopped() && m_communication->IsOpen())
   {
     // wait for a new incoming command, and process it
-    if (m_inBuffer.Pop(command, CEC_PROCESSOR_SIGNAL_WAIT_TIME))
+    if (m_inBuffer.Pop(command, timeout))
       ProcessCommand(command);
 
     if (CECInitialised() && !IsStopped())
     {
       // check clients for keypress timeouts
-      m_libcec->CheckKeypressTimeout();
+      timeout = m_libcec->CheckKeypressTimeout();
 
       // check if we need to replace handlers
       ReplaceHandlers();
@@ -311,6 +311,8 @@ void *CCECProcessor::Process(void)
         tvPresentCheck.Init(TV_PRESENT_CHECK_INTERVAL);
       }
     }
+    else
+      timeout = CEC_PROCESSOR_SIGNAL_WAIT_TIME;
   }
 
   return NULL;

--- a/src/libcec/LibCEC.cpp
+++ b/src/libcec/LibCEC.cpp
@@ -361,11 +361,17 @@ bool CLibCEC::IsValidPhysicalAddress(uint16_t iPhysicalAddress)
          iPhysicalAddress <= CEC_MAX_PHYSICAL_ADDRESS;
 }
 
-void CLibCEC::CheckKeypressTimeout(void)
+uint16_t CLibCEC::CheckKeypressTimeout(void)
 {
+  uint16_t timeout = CEC_PROCESSOR_SIGNAL_WAIT_TIME;
   // check all clients
   for (std::vector<CECClientPtr>::iterator it = m_clients.begin(); it != m_clients.end(); it++)
-    (*it)->CheckKeypressTimeout();
+  {
+    uint16_t t = (*it)->CheckKeypressTimeout();
+    if (t < timeout)
+      timeout = t;
+  }
+  return timeout;
 }
 
 void CLibCEC::AddLog(const cec_log_level level, const char *strFormat, ...)

--- a/src/libcec/LibCEC.h
+++ b/src/libcec/LibCEC.h
@@ -39,6 +39,8 @@
 #include "CECTypeUtils.h"
 #include <memory>
 
+#define CEC_PROCESSOR_SIGNAL_WAIT_TIME 1000
+
 namespace CEC
 {
   class CAdapterCommunication;
@@ -125,7 +127,7 @@ namespace CEC
 
       void AddLog(const cec_log_level level, const char *strFormat, ...);
       void AddCommand(const cec_command &command);
-      void CheckKeypressTimeout(void);
+      uint16_t CheckKeypressTimeout(void);
       void Alert(const libcec_alert type, const libcec_parameter &param);
 
       static bool IsValidPhysicalAddress(uint16_t iPhysicalAddress);

--- a/src/libcec/implementations/CECCommandHandler.cpp
+++ b/src/libcec/implementations/CECCommandHandler.cpp
@@ -797,7 +797,7 @@ int CCECCommandHandler::HandleUserControlRelease(const cec_command &command)
 
   CECClientPtr client = m_processor->GetClient(command.destination);
   if (client)
-    client->AddKey();
+    client->AddKey(false, true);
 
   return COMMAND_HANDLED;
 }


### PR DESCRIPTION
CEC remotes all handle repeating buttons differently. Often they only repeat 2 or 3 times per second which is unpleasantly slow for scrolling in Kodi.

The aim here is to filter out the remote's repeat rate and replace it with configurable delay/repeat settings similar to a keyboard.

To make use of this in kodi you need to configure some settings:
https://github.com/popcornmix/xbmc/commit/994763166355f5e9bc57bcf17099f86c09ad02d1

and this is also useful:
https://github.com/popcornmix/xbmc/commit/89d34a06c735277aa3fc69ca41c66f54b3d17e75

You can see the behaviour with a [Milhouse](http://forum.kodi.tv/showthread.php?tid=231092) OE build on Pi. By default there is no change, but set:
"Remote button press delay before repeating (ms)" to 300
"Remote button press repeat rate (ms)" to 100

and you should find scrolling lists in kodi much more pleasant.

These patches have been in Milhouse builds for a many months, and are in the current OSMC stable builds. Reports are positive. 