### PR TITLE
Fix for holding buttons on remotes of Philips TVs

### DIFF
--- a/src/libcec/implementations/PHCommandHandler.cpp
+++ b/src/libcec/implementations/PHCommandHandler.cpp
@@ -131,9 +131,28 @@ bool CPHCommandHandler::ActivateSource(bool bTransmitDelayedCommandsOnly /* = fa
 
 int CPHCommandHandler::HandleUserControlPressed(const cec_command& command)
 {
-  // TV sometimes keeps sending key presses without releases
+  // TV sends key presses without releases when holding a button
   if (m_iLastKeyCode == command.parameters[0])
-    return COMMAND_HANDLED;
+  {
+    // TV keeps sending key presses after pressing the display information key once (arguably another firmware bug)
+    // So we only allow holding buttons forwarded from the 'device menu control feature' (see cec specs 1.3a table 27)
+    if (m_iLastKeyCode <= CEC_USER_CONTROL_CODE_LEFT_DOWN ||  
+        m_iLastKeyCode == CEC_USER_CONTROL_CODE_EXIT || 
+       (m_iLastKeyCode >= CEC_USER_CONTROL_CODE_NUMBER0 && m_iLastKeyCode <= CEC_USER_CONTROL_CODE_NUMBER9) || 
+       (m_iLastKeyCode >= CEC_USER_CONTROL_CODE_F1_BLUE && m_iLastKeyCode <= CEC_USER_CONTROL_CODE_F5))
+    {
+      cec_command release;
+      release.parameters.size = 0;
+      release.opcode = CEC_OPCODE_USER_CONTROL_RELEASE;
+      release.initiator = command.initiator;
+      release.destination = command.destination;
+      CCECCommandHandler::HandleUserControlRelease(release);
+    }
+    else
+    {
+      return COMMAND_HANDLED;
+    }
+  }
 
   m_iLastKeyCode = command.parameters[0];
 


### PR DESCRIPTION
This fix generates a user-control-released event in case there are two consecutive user-control-pressed events of the same key without the release in between.

This would fix #124 #95 #66

Since I don't own other TVs, it may be good to cross check functionality with TVs from other vendors before merging.

edit: You can find further explanation and logs of the current problematic behaviour here: https://github.com/Pulse-Eight/libcec/issues/95#issuecomment-127634568