### PR TITLE
fixing initialisation issue found on Raspberry Pi with Buildroot

### DIFF
--- a/src/libcec/adapter/RPi/RPiCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/RPi/RPiCECAdapterCommunication.cpp
@@ -71,7 +71,8 @@ CRPiCECAdapterCommunication::CRPiCECAdapterCommunication(IAdapterCommunicationCa
     m_bLogicalAddressChanged(false),
     m_previousLogicalAddress(CECDEVICE_FREEUSE),
     m_bLogicalAddressRegistered(false),
-    m_bDisableCallbacks(false)
+    m_bDisableCallbacks(false),
+    m_bInitialised(false)
 {
   m_queue = new CRPiCECAdapterMessageQueue(this);
 }


### PR DESCRIPTION
Hello, 

I'm working on Buildroot and the Raspberry Pi. I have found that I could not use the cec-client on my board because I would always get the following message : 

 # echo scan | ./cec-client RPI
 No device type given. Using 'recording device' 
 CEC Parser created - libCEC version 2.2.0
 opening a connection to the CEC adapter...
 DEBUG:   [               9]     unregistering all CEC clients
 DEBUG:   [              11]     Broadcast (F): osd name set to 'Broadcast'
 assertion failure:/home/pkvk9345/buildroot-2015.05/output/build/rpi-userland- 8f542a1647e6f88f254eadd9ad6929301c81913b/interface/vmcs_host/vc_vchi_tvservice.c:436:vc_tv_unregister_callback():done

After some debugging I found that the value of m_bInitialised is not set to false by default when creating the object, and hence the tools starts by trying to unregister a callback that isn't registered, and failing to do this, aborts. 

The patch herewith seems to entirely fix the issue in my setup.