### PR TITLE
fixed: Crash on systems without /sys/class/drm

### DIFF
--- a/src/libcec/platform/drm/drm-edid.cpp
+++ b/src/libcec/platform/drm/drm-edid.cpp
@@ -51,6 +51,12 @@ uint16_t CDRMEdidParser::GetPhysicalAddress(void)
  
   DIR *dir = opendir(baseDir.c_str());
 
+  // DRM subfolder may not exist on some systems
+  if (dir == NULL)
+  {
+    return iPA;
+  }
+
   struct dirent *entry = readdir(dir);
   std::string enablededid;
   std::string line;


### PR DESCRIPTION
Reported to Debian BTS:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=798190
The fix has been verified by the reporter.