### PR TITLE
Add ability to set LogLevel to 0 to suppress ALL messages

### DIFF
--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -822,6 +822,7 @@ typedef enum cec_opcode
 
 typedef enum cec_log_level
 {
+  CEC_LOG_NONE    = 0,
   CEC_LOG_ERROR   = 1,
   CEC_LOG_WARNING = 2,
   CEC_LOG_NOTICE  = 4,

--- a/src/cec-client/cec-client.cpp
+++ b/src/cec-client/cec-client.cpp
@@ -882,7 +882,7 @@ bool ProcessCommandLOG(ICECAdapter * UNUSED(parser), const std::string &command,
     if (GetWord(arguments, strLevel))
     {
       int iNewLevel = atoi(strLevel.c_str());
-      if (iNewLevel >= CEC_LOG_ERROR && iNewLevel <= CEC_LOG_ALL)
+      if (iNewLevel >= CEC_LOG_NONE && iNewLevel <= CEC_LOG_ALL)
       {
         g_cecLogLevel = iNewLevel;
 
@@ -1021,7 +1021,7 @@ bool ProcessCommandLineArguments(int argc, char *argv[])
         if (argc >= iArgPtr + 2)
         {
           int iNewLevel = atoi(argv[iArgPtr + 1]);
-          if (iNewLevel >= CEC_LOG_ERROR && iNewLevel <= CEC_LOG_ALL)
+          if (iNewLevel >= CEC_LOG_NONE && iNewLevel <= CEC_LOG_ALL)
           {
             g_cecLogLevel = iNewLevel;
             if (!g_bSingleCommand)

--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -127,7 +127,7 @@ static int cec_process_command_line_arguments(int argc, char *argv[])
         if (argc >= iArgPtr + 2)
         {
           int iNewLevel = atoi(argv[iArgPtr + 1]);
-          if (iNewLevel >= CEC_LOG_ERROR && iNewLevel <= CEC_LOG_ALL)
+          if (iNewLevel >= CEC_LOG_NONE && iNewLevel <= CEC_LOG_ALL)
           {
             g_cecLogLevel = iNewLevel;
             if (!g_bSingleCommand)


### PR DESCRIPTION
Added ability to suppress all output by setting LogLevel to 0 through the command line option '-d 0' or internal command 'log 0'.