### PR TITLE
Use a single number as major SO version like others

### DIFF
--- a/include/ceccloader.h
+++ b/include/ceccloader.h
@@ -225,7 +225,7 @@ static libcecc_lib_instance_t libcecc_load_library(const char* strLib)
   #if defined(__APPLE__)
     lib =  dlopen(strLib ? strLib : "libcec." CEC_LIB_VERSION_MAJOR_STR ".dylib", RTLD_LAZY);
   #else
-    lib = dlopen(strLib ? strLib : "libcec.so." CEC_LIB_VERSION_MAJOR_STR ".0", RTLD_LAZY);
+    lib = dlopen(strLib ? strLib : "libcec.so." CEC_LIB_VERSION_MAJOR_STR, RTLD_LAZY);
   #endif
   if (lib == NULL)
     printf("%s\n", dlerror());

--- a/include/cecloader.h
+++ b/include/cecloader.h
@@ -121,7 +121,7 @@ CEC::ICECAdapter *LibCecInitialise(CEC::libcec_configuration *configuration, con
 #if defined(__APPLE__)
     g_libCEC = dlopen(strLib ? strLib : "libcec." CEC_LIB_VERSION_MAJOR_STR ".dylib", RTLD_LAZY);
 #else
-    g_libCEC = dlopen(strLib ? strLib : "libcec.so." CEC_LIB_VERSION_MAJOR_STR ".0", RTLD_LAZY);
+    g_libCEC = dlopen(strLib ? strLib : "libcec.so." CEC_LIB_VERSION_MAJOR_STR, RTLD_LAZY);
 #endif
     if (!g_libCEC)
     {

--- a/src/libcec/CMakeLists.txt
+++ b/src/libcec/CMakeLists.txt
@@ -174,7 +174,7 @@ add_library(cec SHARED ${CEC_SOURCES})
 install(TARGETS cec
         DESTINATION ${LIB_DESTINATION})
 set_target_properties(cec PROPERTIES VERSION   ${LIBCEC_VERSION_MAJOR}.${LIBCEC_VERSION_MINOR}.${LIBCEC_VERSION_PATCH}
-                                     SOVERSION ${LIBCEC_VERSION_MAJOR}.0)
+                                     SOVERSION ${LIBCEC_VERSION_MAJOR})
 target_link_libraries(cec ${platform_LIBRARIES})
 target_link_libraries(cec ${CMAKE_THREAD_LIBS_INIT})
 


### PR DESCRIPTION
This change is being used in the package shipped by Debian to match shared library naming conventions. Probably the best time for for merging it would be before a major SO version bump.
