### PR TITLE
Don't skip checking for Raspberry Pi library (Fixes #166).

### DIFF
--- a/src/libcec/cmake/CheckPlatformSupport.cmake
+++ b/src/libcec/cmake/CheckPlatformSupport.cmake
@@ -93,8 +93,9 @@ else()
 
   # raspberry pi
   find_library(RPI_BCM_HOST bcm_host "${RPI_LIB_DIR}")
-  check_library_exists(bcm_host bcm_host_init "${RPI_LIB_DIR}" HAVE_RPI_API)
-  if (HAVE_RPI_API)
+  check_library_exists(bcm_host bcm_host_init "${RPI_LIB_DIR}" HAVE_RPI_LIB)
+  if (HAVE_RPI_LIB)
+    set(HAVE_RPI_API 1)
     find_library(RPI_VCOS vcos "${RPI_LIB_DIR}")
     find_library(RPI_VCHIQ_ARM vchiq_arm "${RPI_LIB_DIR}")
     include_directories(${RPI_INCLUDE_DIR} ${RPI_INCLUDE_DIR}/interface/vcos/pthreads ${RPI_INCLUDE_DIR}/interface/vmcs_host/linux)


### PR DESCRIPTION
This fixes the build for me on Raspberry Pi. 

Before:
```
-- Looking for XRRGetScreenResources in Xrandr
-- Looking for XRRGetScreenResources in Xrandr - found
-- Found SWIG: /usr/bin/swig2.0 (found version "2.0.12") 
-- Configured features:
-- Pulse-Eight CEC Adapter:                yes
-- Pulse-Eight CEC Adapter detection:      yes
-- xrandr support:                         yes
-- Raspberry Pi support:                   no

```

After:
```
-- Looking for XRRGetScreenResources in Xrandr
-- Looking for XRRGetScreenResources in Xrandr - found
-- Looking for bcm_host_init in bcm_host
-- Looking for bcm_host_init in bcm_host - found
-- Found SWIG: /usr/bin/swig2.0 (found version "2.0.12") 
-- Configured features:
-- Pulse-Eight CEC Adapter:                yes
-- Pulse-Eight CEC Adapter detection:      yes
-- xrandr support:                         yes
-- Raspberry Pi support:                   yes
```

I believe I have already signed the developer agreement. 