### PR TITLE
Fix typos in comments and strings

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -282,7 +282,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # causing a significant performance penality. 
 # If the system has enough physical memory increasing the cache will improve the 
 # performance by keeping more symbols in memory. Note that the value works on 
-# a logarithmic scale so increasing the size by one will rougly double the 
+# a logarithmic scale so increasing the size by one will roughly double the
 # memory usage. The cache size is given by this formula: 
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0, 
 # corresponding to a cache size of 2^16 = 65536 symbols

--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -475,7 +475,7 @@ libcec (1.8.2-1) unstable; urgency=low
     * ensure that the vendor commands are always sent for panasonic, and that
       the deck status for lg isn't reset. fixes some buttons not working after
       a second or delayed source switch
-    * added guard so ReplaceHandler() doesn't accidently try to replace a
+    * added guard so ReplaceHandler() doesn't accidentally try to replace a
       handler for the broadcast address
     * wait until the commandhandler is replaced before registering a client,
       so we don't register a client and replace it directly afterwards if the
@@ -505,7 +505,7 @@ libcec (1.8.1-1) unstable; urgency=low
     * disallow sending CEC_OPCODE_SET_STREAM_PATH - not allowed by the CEC spec
     * persist the configuration in the eeprom after initialising the client.
       fixes wrong/old settings being used in autonomous mode, which broke the
-      wake on cec funtion
+      wake on cec function
     * persist the new configuration when the hdmi port setting changed
     * cleaned locks around callbacks
     * always set controlled mode to false when unregistering the last client.
@@ -559,7 +559,7 @@ libcec (1.7.2-1) unstable; urgency=low
     * panasonic: mark the tv as powered up once it sends the audiomode request
     * set the physical address of each device controlled by a CCECClient if
       it's valid
-    * Windows could get stuck in a loop in case there an error occured while
+    * Windows could get stuck in a loop in case there an error occurred while
       reading registry entries
     * ABI fixes (binary compat with v1.2 for Windows and v1.5.2 for others)
     * replace the handler directly after getting the vendor id of a device when
@@ -801,7 +801,7 @@ libcec (1.6-1) unstable; urgency=medium
     * added bShutdownOnStandby to libcec_configuration. bugzid: 660. This
       setting tells the client to shutdown when the TV switches off and is
       complimentary to bPowerOffOnStandby, which tells the PC to suspend.
-      They are kept separate to maintain backwards compatability.
+      They are kept separate to maintain backwards compatibility.
 
   * fixed
     * gcc 4.7 compilation
@@ -1105,7 +1105,7 @@ libcec (1.4-4) unstable; urgency=low
     * close and delete the connection when the processor thread ends. fixes
       reconnect after standby (access denied / connection already opened)
     * don't replace handlers when not initialised, or the primary device's
-      logical addres isn't known yet, which can lead to crashes. don't call
+      logical address isn't known yet, which can lead to crashes. don't call
       handlers directly in CCECProcessor without holding a lock on them
     * fixed possible crash when command handler were switched while it was
       being used
@@ -1454,8 +1454,8 @@ libcec (0.8-1) unstable; urgency=low
   * fixed:
     * set the correct ackmask on startup
     * wait for ack while keeping a lock
-    * wait for the processor thread to start before continueing on startup
-    * wait for messages to be transmitted before continueing in
+    * wait for the processor thread to start before continuing on startup
+    * wait for messages to be transmitted before continuing in
       CCECProcessor::Transmit()
     * only set the logical address once when it has changed
     * correct source for broadcast messages
@@ -1541,7 +1541,7 @@ libcec (0.6-1) unstable; urgency=low
 libcec (0.5-1) unstable; urgency=low
 
   * bumped interface version to 5
-  * don't pass std::string and std::vector accross the interface
+  * don't pass std::string and std::vector across the interface
   * fixed heap corruption crashes on windows
   * fixed some memory leaks
   * reset all structs to default values before doing with them
@@ -1566,7 +1566,7 @@ libcec (0.4-2) unstable; urgency=low
   * fix segfault on exit
   * renamed libPlatform -> platform.
   * stuck everything from libCEC in the CEC namespace to avoid namespace
-    polution
+    pollution
 
  -- Pulse-Eight Packaging <packaging@pulse-eight.com>  Tue, 04 Oct 2011 23:45:00 +0200
 

--- a/include/cec.h
+++ b/include/cec.h
@@ -76,13 +76,13 @@ namespace CEC
      * @param deviceList The vector to store device descriptors in.
      * @param iBufSize The size of the deviceList buffer.
      * @param strDevicePath Optional device path. Only adds device descriptors that match the given device path.
-     * @return The number of devices that were found, or -1 when an error occured.
+     * @return The number of devices that were found, or -1 when an error occurred.
      */
     virtual int8_t FindAdapters(cec_adapter *deviceList, uint8_t iBufSize, const char *strDevicePath = NULL) = 0;
 
     /*!
      * @brief Sends a ping command to the adapter, to check if it's responding.
-     * @return True when the ping was succesful, false otherwise.
+     * @return True when the ping was successful, false otherwise.
      */
     virtual bool PingAdapter(void) = 0;
 
@@ -117,21 +117,21 @@ namespace CEC
     /*!
      * @brief Power on the given CEC capable devices. If CECDEVICE_BROADCAST is used, then wakeDevice in libcec_configuration will be used.
      * @param address The logical address to power on.
-     * @return True when the command was sent succesfully, false otherwise.
+     * @return True when the command was sent successfully, false otherwise.
      */
     virtual bool PowerOnDevices(cec_logical_address address = CECDEVICE_TV) = 0;
 
     /*!
      * @brief Put the given CEC capable devices in standby mode. If CECDEVICE_BROADCAST is used, then standbyDevices in libcec_configuration will be used.
      * @brief address The logical address of the device to put in standby.
-     * @return True when the command was sent succesfully, false otherwise.
+     * @return True when the command was sent successfully, false otherwise.
      */
     virtual bool StandbyDevices(cec_logical_address address = CECDEVICE_BROADCAST) = 0;
 
     /*!
      * @brief Change the active source to a device type handled by libCEC. Use CEC_DEVICE_TYPE_RESERVED to make the default type used by libCEC active.
      * @param type The new active source. Leave empty to use the primary type
-     * @return True when the command was sent succesfully, false otherwise.
+     * @return True when the command was sent successfully, false otherwise.
      */
     virtual bool SetActiveSource(cec_device_type type = CEC_DEVICE_TYPE_RESERVED) = 0;
 
@@ -153,7 +153,7 @@ namespace CEC
 
     /*!
      * @brief Broadcast a message that notifies connected CEC capable devices that this device is no longer the active source.
-     * @return True when the command was sent succesfully, false otherwise.
+     * @return True when the command was sent successfully, false otherwise.
      */
     virtual bool SetInactiveView(void) = 0;
 
@@ -192,7 +192,7 @@ namespace CEC
      * @brief Get the menu language of the device with the given logical address
      * @param iLogicalAddress The logical address of the device to get the menu language for.
      * @param language The requested menu language.
-     * @return True when fetched succesfully, false otherwise.
+     * @return True when fetched successfully, false otherwise.
      */
     virtual bool GetDeviceMenuLanguage(cec_logical_address iLogicalAddress, cec_menu_language *language) = 0;
 
@@ -455,7 +455,7 @@ namespace CEC
      * @param iBufSize The size of the deviceList buffer.
      * @param strDevicePath Optional device path. Only adds device descriptors that match the given device path.
      * @param bQuickScan True to do a "quick scan", which will not open a connection to the adapter. Firmware version information and the exact device type will be missing
-     * @return The number of devices that were found, or -1 when an error occured.
+     * @return The number of devices that were found, or -1 when an error occurred.
      */
     virtual int8_t DetectAdapters(cec_adapter_descriptor *deviceList, uint8_t iBufSize, const char *strDevicePath = NULL, bool bQuickScan = false) = 0;
 

--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -1080,7 +1080,7 @@ typedef struct cec_command
    * @brief Formats a cec_command.
    * @param command The command to format.
    * @param initiator The logical address of the initiator.
-   * @param destination The logical addres of the destination.
+   * @param destination The logical address of the destination.
    * @param opcode The opcode of the command.
    * @param timeout The transmission timeout.
    */
@@ -1490,7 +1490,7 @@ struct libcec_configuration
   uint8_t               bMonitorOnly;         /*!< won't allocate a CCECClient when starting the connection when set (same as monitor mode). added in 1.6.3 */
   cec_version           cecVersion;           /*!< CEC spec version to use by libCEC. defaults to v1.4. added in 1.8.0 */
   cec_adapter_type      adapterType;          /*!< type of the CEC adapter that we're connected to. added in 1.8.2 */
-  uint8_t               iDoubleTapTimeout50Ms;  /*!< prevent double taps withing this timeout, in units of 50ms. defaults to 200ms (value: 4). added in 2.0.0,
+  uint8_t               iDoubleTapTimeout50Ms;  /*!< prevent double taps within this timeout, in units of 50ms. defaults to 200ms (value: 4). added in 2.0.0,
                                                    XXX changed meaning in 2.2.0 to not break binary compatibility. next major (3.0) release will fix it in a nicer way */
   cec_user_control_code comboKey;             /*!< key code that initiates combo keys. defaults to CEC_USER_CONTROL_CODE_F1_BLUE. CEC_USER_CONTROL_CODE_UNKNOWN to disable. added in 2.0.5 */
   uint32_t              iComboKeyTimeoutMs;   /*!< timeout until the combo key is sent as normal keypress */

--- a/src/LibCecSharp/CecSharpTypes.h
+++ b/src/LibCecSharp/CecSharpTypes.h
@@ -828,7 +828,7 @@ namespace CecSharp
     /// </summary>
     VolumeStatusMask    = 0x7F,
     /// <summary>
-    /// Minumum volume
+    /// Minimum volume
     /// </summary>
     VolumeMin           = 0x00,
     /// <summary>

--- a/src/LibCecSharp/LibCecSharp.cpp
+++ b/src/LibCecSharp/LibCecSharp.cpp
@@ -147,7 +147,7 @@ namespace CecSharp
     /// <summary>
     /// Sends a ping command to the adapter, to check if it's responding.
     /// </summary>
-    /// <returns>True when the ping was succesful, false otherwise</returns>
+    /// <returns>True when the ping was successful, false otherwise</returns>
     bool PingAdapter(void)
     {
       return m_libCec->PingAdapter();
@@ -204,7 +204,7 @@ namespace CecSharp
     /// Power on the given CEC capable devices. If CECDEVICE_BROADCAST is used, then wakeDevice in libcec_configuration will be used.
     /// </summary>
     /// <param name="logicalAddress">The logical address to power on.</param>
-    /// <returns>True when the command was sent succesfully, false otherwise.</returns>
+    /// <returns>True when the command was sent successfully, false otherwise.</returns>
     bool PowerOnDevices(CecLogicalAddress logicalAddress)
     {
       return m_libCec->PowerOnDevices((cec_logical_address) logicalAddress);
@@ -214,7 +214,7 @@ namespace CecSharp
     /// Put the given CEC capable devices in standby mode. If CECDEVICE_BROADCAST is used, then standbyDevices in libcec_configuration will be used.
     /// </summary>
     /// <param name="logicalAddress">The logical address of the device to put in standby.</param>
-    /// <returns>True when the command was sent succesfully, false otherwise.</returns>
+    /// <returns>True when the command was sent successfully, false otherwise.</returns>
     bool StandbyDevices(CecLogicalAddress logicalAddress)
     {
       return m_libCec->StandbyDevices((cec_logical_address) logicalAddress);
@@ -234,7 +234,7 @@ namespace CecSharp
     /// Change the active source to a device type handled by libCEC. Use CEC_DEVICE_TYPE_RESERVED to make the default type used by libCEC active.
     /// </summary>
     /// <param name="type">The new active source. Use CEC_DEVICE_TYPE_RESERVED to use the primary type</param>
-    /// <returns>True when the command was sent succesfully, false otherwise.</returns>
+    /// <returns>True when the command was sent successfully, false otherwise.</returns>
     bool SetActiveSource(CecDeviceType type)
     {
       return m_libCec->SetActiveSource((cec_device_type) type);
@@ -265,7 +265,7 @@ namespace CecSharp
     /// <summary>
     /// Broadcast a message that notifies connected CEC capable devices that this device is no longer the active source.
     /// </summary>
-    /// <returns>True when the command was sent succesfully, false otherwise.</returns>
+    /// <returns>True when the command was sent successfully, false otherwise.</returns>
     bool SetInactiveView(void)
     {
       return m_libCec->SetInactiveView();

--- a/src/cec-client/cec-client.cpp
+++ b/src/cec-client/cec-client.cpp
@@ -292,7 +292,7 @@ void ShowHelpCommandLine(const char* strExec)
       "  -l --list-devices           List all devices on this system" << std::endl <<
       "  -t --type {p|r|t|a}         The device type to use. More than one is possible." << std::endl <<
       "  -p --port {int}             The HDMI port to use as active source." << std::endl <<
-      "  -b --base {int}             The logical address of the device to with this " << std::endl <<
+      "  -b --base {int}             The logical address of the device to which this " << std::endl <<
       "                              adapter is connected." << std::endl <<
       "  -f --log-file {file}        Writes all libCEC log message to a file" << std::endl <<
       "  -r --rom                    Read persisted settings from the EEPROM" << std::endl <<

--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -118,7 +118,7 @@ bool CCECClient::OnRegister(void)
   // return false when no devices were found
   if (devices.empty())
   {
-    LIB_CEC->AddLog(CEC_LOG_WARNING, "cannot find the primary device (logical address %x)", GetPrimaryLogicalAdddress());
+    LIB_CEC->AddLog(CEC_LOG_WARNING, "cannot find the primary device (logical address %x)", GetPrimaryLogicalAddress());
     return false;
   }
 
@@ -129,7 +129,7 @@ bool CCECClient::OnRegister(void)
   for (CECDEVICEVEC::iterator it = devices.begin(); it != devices.end(); it++)
   {
     // only set our OSD name for the primary device
-    if ((*it)->GetLogicalAddress() == GetPrimaryLogicalAdddress())
+    if ((*it)->GetLogicalAddress() == GetPrimaryLogicalAddress())
       (*it)->SetOSDName(m_configuration.strDeviceName);
 
     // set the default menu language for devices we control
@@ -177,7 +177,7 @@ bool CCECClient::SetHDMIPort(const cec_logical_address iBaseDevice, const uint8_
   uint16_t iPhysicalAddress(CEC_INVALID_PHYSICAL_ADDRESS);
   CCECBusDevice *baseDevice = m_processor->GetDevice(iBaseDevice);
   if (baseDevice)
-    iPhysicalAddress = baseDevice->GetPhysicalAddress(GetPrimaryLogicalAdddress());
+    iPhysicalAddress = baseDevice->GetPhysicalAddress(GetPrimaryLogicalAddress());
 
   // add our port number
   if (iPhysicalAddress <= CEC_MAX_PHYSICAL_ADDRESS)
@@ -483,7 +483,7 @@ bool CCECClient::SetLogicalAddress(const cec_logical_address iLogicalAddress)
 {
   bool bReturn(true);
 
-  if (GetPrimaryLogicalAdddress() != iLogicalAddress)
+  if (GetPrimaryLogicalAddress() != iLogicalAddress)
   {
     LIB_CEC->AddLog(CEC_LOG_NOTICE, "setting primary logical address to %1x", iLogicalAddress);
     {
@@ -514,10 +514,10 @@ bool CCECClient::SendPowerOnDevices(const cec_logical_address address /* = CECDE
   {
     CECDEVICEVEC devices;
     m_processor->GetDevices()->GetWakeDevices(m_configuration, devices);
-    return m_processor->PowerOnDevices(GetPrimaryLogicalAdddress(), devices);
+    return m_processor->PowerOnDevices(GetPrimaryLogicalAddress(), devices);
   }
 
-  return m_processor->PowerOnDevice(GetPrimaryLogicalAdddress(), address);
+  return m_processor->PowerOnDevice(GetPrimaryLogicalAddress(), address);
 }
 
 bool CCECClient::SendStandbyDevices(const cec_logical_address address /* = CECDEVICE_BROADCAST */)
@@ -527,10 +527,10 @@ bool CCECClient::SendStandbyDevices(const cec_logical_address address /* = CECDE
   {
     CECDEVICEVEC devices;
     m_processor->GetDevices()->GetPowerOffDevices(m_configuration, devices);
-    return m_processor->StandbyDevices(GetPrimaryLogicalAdddress(), devices);
+    return m_processor->StandbyDevices(GetPrimaryLogicalAddress(), devices);
   }
 
-  return m_processor->StandbyDevice(GetPrimaryLogicalAdddress(), address);
+  return m_processor->StandbyDevice(GetPrimaryLogicalAddress(), address);
 }
 
 bool CCECClient::SendSetActiveSource(const cec_device_type type /* = CEC_DEVICE_TYPE_RESERVED */)
@@ -585,7 +585,7 @@ CCECPlaybackDevice *CCECClient::GetPlaybackDevice(void)
   return device;
 }
 
-cec_logical_address CCECClient::GetPrimaryLogicalAdddress(void)
+cec_logical_address CCECClient::GetPrimaryLogicalAddress(void)
 {
   CLockObject lock(m_mutex);
   return m_configuration.logicalAddresses.primary;
@@ -593,7 +593,7 @@ cec_logical_address CCECClient::GetPrimaryLogicalAdddress(void)
 
 CCECBusDevice *CCECClient::GetPrimaryDevice(void)
 {
-  return m_processor->GetDevice(GetPrimaryLogicalAdddress());
+  return m_processor->GetDevice(GetPrimaryLogicalAddress());
 }
 
 bool CCECClient::SendSetDeckControlMode(const cec_deck_control_mode mode, bool bSendUpdate /* = true */)
@@ -677,7 +677,7 @@ cec_version CCECClient::GetDeviceCecVersion(const cec_logical_address iAddress)
 {
   CCECBusDevice *device = m_processor->GetDevice(iAddress);
   if (device)
-    return device->GetCecVersion(GetPrimaryLogicalAdddress());
+    return device->GetCecVersion(GetPrimaryLogicalAddress());
   return CEC_VERSION_UNKNOWN;
 }
 
@@ -686,7 +686,7 @@ bool CCECClient::GetDeviceMenuLanguage(const cec_logical_address iAddress, cec_m
   CCECBusDevice *device = m_processor->GetDevice(iAddress);
   if (device)
   {
-    language = device->GetMenuLanguage(GetPrimaryLogicalAdddress());
+    language = device->GetMenuLanguage(GetPrimaryLogicalAddress());
     return (strcmp(language.language, "???") != 0);
   }
   return false;
@@ -701,7 +701,7 @@ cec_osd_name CCECClient::GetDeviceOSDName(const cec_logical_address iAddress)
   CCECBusDevice *device = m_processor->GetDevice(iAddress);
   if (device)
   {
-    std::string strOSDName = device->GetOSDName(GetPrimaryLogicalAdddress());
+    std::string strOSDName = device->GetOSDName(GetPrimaryLogicalAddress());
     snprintf(retVal.name, sizeof(retVal.name), "%s", strOSDName.c_str());
     retVal.device = iAddress;
   }
@@ -713,7 +713,7 @@ uint16_t CCECClient::GetDevicePhysicalAddress(const cec_logical_address iAddress
 {
   CCECBusDevice *device = m_processor->GetDevice(iAddress);
   if (device)
-    return device->GetPhysicalAddress(GetPrimaryLogicalAdddress());
+    return device->GetPhysicalAddress(GetPrimaryLogicalAddress());
   return CEC_INVALID_PHYSICAL_ADDRESS;
 }
 
@@ -721,7 +721,7 @@ cec_power_status CCECClient::GetDevicePowerStatus(const cec_logical_address iAdd
 {
   CCECBusDevice *device = m_processor->GetDevice(iAddress);
   if (device)
-    return device->GetPowerStatus(GetPrimaryLogicalAdddress());
+    return device->GetPowerStatus(GetPrimaryLogicalAddress());
   return CEC_POWER_STATUS_UNKNOWN;
 }
 
@@ -729,7 +729,7 @@ uint32_t CCECClient::GetDeviceVendorId(const cec_logical_address iAddress)
 {
   CCECBusDevice *device = m_processor->GetDevice(iAddress);
   if (device)
-    return device->GetVendorId(GetPrimaryLogicalAdddress());
+    return device->GetVendorId(GetPrimaryLogicalAddress());
   return CEC_VENDOR_UNKNOWN;
 }
 
@@ -807,7 +807,7 @@ bool CCECClient::SendKeypress(const cec_logical_address iDestination, const cec_
   CCECBusDevice *dest = m_processor->GetDevice(iDestination);
 
   return dest ?
-      dest->TransmitKeypress(GetPrimaryLogicalAdddress(), key, bWait) :
+      dest->TransmitKeypress(GetPrimaryLogicalAddress(), key, bWait) :
       false;
 }
 
@@ -816,7 +816,7 @@ bool CCECClient::SendKeyRelease(const cec_logical_address iDestination, bool bWa
   CCECBusDevice *dest = m_processor->GetDevice(iDestination);
 
   return dest ?
-      dest->TransmitKeyRelease(GetPrimaryLogicalAdddress(), bWait) :
+      dest->TransmitKeyRelease(GetPrimaryLogicalAddress(), bWait) :
       false;
 }
 

--- a/src/libcec/CECClient.h
+++ b/src/libcec/CECClient.h
@@ -185,7 +185,7 @@ namespace CEC
     /*!
      * @return The primary logical address that this client is controlling.
      */
-    virtual cec_logical_address GetPrimaryLogicalAdddress(void);
+    virtual cec_logical_address GetPrimaryLogicalAddress(void);
 
     /*!
      * @return The primary device that this client is controlling, or NULL if none.

--- a/src/libcec/CECProcessor.cpp
+++ b/src/libcec/CECProcessor.cpp
@@ -895,7 +895,7 @@ bool CCECProcessor::RegisterClient(CECClientPtr client)
   // mark the client as registered
   client->SetRegistered(true);
 
-  sourceAddress = client->GetPrimaryLogicalAdddress();
+  sourceAddress = client->GetPrimaryLogicalAddress();
 
   // initialise the client
   bool bReturn = client->OnRegister();

--- a/src/libcec/adapter/AdapterCommunication.h
+++ b/src/libcec/adapter/AdapterCommunication.h
@@ -47,7 +47,7 @@ namespace CEC
     ADAPTER_MESSAGE_STATE_SENT_NOT_ACKED,     /**< sent, but failed to ACK */
     ADAPTER_MESSAGE_STATE_SENT_ACKED,         /**< sent, and ACK received */
     ADAPTER_MESSAGE_STATE_INCOMING,           /**< received from another device */
-    ADAPTER_MESSAGE_STATE_ERROR               /**< an error occured */
+    ADAPTER_MESSAGE_STATE_ERROR               /**< an error occurred */
   } cec_adapter_message_state;
 
   class IAdapterCommunicationCallback

--- a/src/libcec/adapter/RPi/RPiCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/RPi/RPiCECAdapterCommunication.cpp
@@ -393,7 +393,7 @@ cec_adapter_message_state CRPiCECAdapterCommunication::Write(const cec_command &
   // (0xf, 0xe respectively) before it calls us for LA POLLing.
   //
   // that means - unregistering any A from adapter, _while_
-  // ignoring callbacks (and especialy not reporting the
+  // ignoring callbacks (and especially not reporting the
   // subsequent actions generated from VC layer - like
   // LA change to 0xf ...)
   //

--- a/src/libcec/cmake/CheckPlatformSupport.cmake
+++ b/src/libcec/cmake/CheckPlatformSupport.cmake
@@ -14,8 +14,8 @@
 #       HAVE_DRM_EDID_PARSER      1 if DRM EDID parsing is supported
 #
 
-set(RPI_LIB_DIR     "" CACHE STRING "Path to Rapsberry Pi libraries")
-set(RPI_INCLUDE_DIR "" CACHE STRING "Path to Rapsberry Pi headers")
+set(RPI_LIB_DIR     "" CACHE STRING "Path to Raspberry Pi libraries")
+set(RPI_INCLUDE_DIR "" CACHE STRING "Path to Raspberry Pi headers")
 
 set(PLATFORM_LIBREQUIRES "")
 

--- a/src/libcec/devices/CECBusDevice.cpp
+++ b/src/libcec/devices/CECBusDevice.cpp
@@ -654,7 +654,7 @@ bool CCECBusDevice::TransmitPhysicalAddress(bool bIsReply)
     if (m_iPhysicalAddress == CEC_INVALID_PHYSICAL_ADDRESS)
       return false;
 
-    LIB_CEC->AddLog(CEC_LOG_DEBUG, "<< %s (%X) -> broadcast (F): physical adddress %4x", GetLogicalAddressName(), m_iLogicalAddress, m_iPhysicalAddress);
+    LIB_CEC->AddLog(CEC_LOG_DEBUG, "<< %s (%X) -> broadcast (F): physical address %4x", GetLogicalAddressName(), m_iLogicalAddress, m_iPhysicalAddress);
     iPhysicalAddress = m_iPhysicalAddress;
     type = m_type;
   }

--- a/src/libcec/devices/CECBusDevice.cpp
+++ b/src/libcec/devices/CECBusDevice.cpp
@@ -328,7 +328,7 @@ void CCECBusDevice::SetUnsupportedFeature(cec_opcode opcode)
     }
   }
 
-  // signal threads that are waiting for a reponse
+  // signal threads that are waiting for a response
   MarkBusy();
   SignalOpcode(cec_command::GetResponseOpcode(opcode));
   MarkReady();

--- a/src/libcec/platform/adl/adl_defines.h
+++ b/src/libcec/platform/adl/adl_defines.h
@@ -978,7 +978,7 @@ enum ADLLARGEDESKTOPTYPE
 #define ADL_DL_THERMAL_FLAG_INTERRUPT    1
 #define ADL_DL_THERMAL_FLAG_FANCONTROL   2
 
-///\defgroup define_fanctrl Fan speed cotrol
+///\defgroup define_fanctrl Fan speed control
 /// Values for ADLFanSpeedInfo.iFlags
 // @{
 #define ADL_DL_FANCTRL_SUPPORTS_PERCENT_READ     1
@@ -1303,7 +1303,7 @@ typedef enum _ADLProfilePropertyType
 /// \defgroup define_adapter_crossdisplay_option
 /// Used in ADL_Adapter_CrossdisplayInfoX2_Set function to indicate cross display options.
 /// @{
-/// Checking if 3D application is runnning. If yes, not to do switch, return ADL_OK_WAIT; otherwise do switch.
+/// Checking if 3D application is running. If yes, don't switch, return ADL_OK_WAIT; otherwise do switch.
 #define ADL_CROSSDISPLAY_OPTION_NONE			0
 /// Force switching without checking for running 3D applications
 #define ADL_CROSSDISPLAY_OPTION_FORCESWITCH		(1 << 0)

--- a/src/libcec/platform/adl/adl_structures.h
+++ b/src/libcec/platform/adl/adl_structures.h
@@ -83,7 +83,7 @@ typedef struct AdapterInfo
 /////////////////////////////////////////////////////////////////////////////////////////////
 ///\brief Structure containing information about the Linux X screen information.
 ///
-/// This structure is used to store the current screen number and xorg.conf ID name assoicated with an adapter index.  
+/// This structure is used to store the current screen number and xorg.conf ID name associated with an adapter index.
 /// This structure is updated during ADL_Main_Control_Refresh or ADL_ScreenInfo_Update.  
 /// Note:  This structure should be used in place of iXScreenNum and strXScreenConfigName in AdapterInfo as they will be 
 /// deprecated.
@@ -397,7 +397,7 @@ typedef struct ADLDisplayDPMSTInfo
 	/// string identifier for the display
 	char	strGlobalUniqueIdentifier[ADL_MAX_PATH]; 
 
-	/// The link count of relative address, rad[0] upto rad[linkCount] are valid
+	/// The link count of relative address, rad[0] up to rad[linkCount] are valid
 	int		radLinkCount;
 	/// The physical connector ID, used to identify the physical DP port
 	int		iPhysicalConnectorID;
@@ -1575,10 +1575,10 @@ typedef struct ADLSLSTarget
 	/// The target ID
     ADLDisplayTarget displayTarget; 
     
-	/// Target postion X in SLS grid
+	/// Target position X in SLS grid
 	int iSLSGridPositionX; 
 
-	/// Target postion Y in SLS grid
+	/// Target position Y in SLS grid
     int iSLSGridPositionY; 
 
 	/// The view size width, height and rotation angle per SLS Target 


### PR DESCRIPTION
Most of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>