### PR TITLE
added: enduring events (long press) in eventghost. fixes #188

### DIFF
--- a/src/EventGhost/__init__.py
+++ b/src/EventGhost/__init__.py
@@ -187,8 +187,14 @@ class CEC(eg.PluginClass):
 
   # key press callback
   def KeyPressCallback(self, key, duration):
-    if duration == 0 or self.lastKeyPressed != key:
+    if duration == 0 and self.lastKeyPressed != key:
       self.lastKeyPressed = key
+      self.TriggerEnduringEvent(self.lib.UserControlCodeToString(key))
+    elif duration > 0 and self.lastKeyPressed == key:
+      self.lastKeyPressed = 255
+      self.EndLastEvent()
+    elif self.lastKeyPressed != key:
+      self.lastKeyPressed = 255
       self.TriggerEvent(self.lib.UserControlCodeToString(key))
     return 0
 

--- a/src/EventGhost/libCEC_Demo_Configuration.xml
+++ b/src/EventGhost/libCEC_Demo_Configuration.xml
@@ -105,11 +105,17 @@
                 <Action>
                     Window.SendKeys(u'{Up}', False)
                 </Action>
+                <Action>
+                    EventGhost.AutoRepeat(0.59999999999999998, 0.29999999999999999, 0.01, 3.0)
+                </Action>
             </Macro>
             <Macro Name="Emulate Keystrokes: {Down}">
                 <Event Name="CEC.down" />
                 <Action>
                     Window.SendKeys(u'{Down}', False)
+                </Action>
+                <Action>
+                    EventGhost.AutoRepeat(0.59999999999999998, 0.29999999999999999, 0.01, 3.0)
                 </Action>
             </Macro>
             <Macro Name="Emulate Keystrokes: {Left}">
@@ -117,17 +123,31 @@
                 <Action>
                     Window.SendKeys(u'{Left}', False)
                 </Action>
+                <Action>
+                    EventGhost.AutoRepeat(0.59999999999999998, 0.29999999999999999, 0.01, 3.0)
+                </Action>
             </Macro>
             <Macro Name="Emulate Keystrokes: {Right}">
                 <Event Name="CEC.right" />
                 <Action>
                     Window.SendKeys(u'{Right}', False)
                 </Action>
+                <Action>
+                    EventGhost.AutoRepeat(0.59999999999999998, 0.29999999999999999, 0.01, 3.0)
+                </Action>
             </Macro>
             <Macro Name="Emulate Keystrokes: {Backspace}">
                 <Event Name="CEC.exit" />
                 <Action>
+                    EventGhost.JumpIfLongPress(1.0, XmlIdLink(25))
+                </Action>
+                <Action>
                     Window.SendKeys(u'{Backspace}', False)
+                </Action>
+            </Macro>
+            <Macro Name="Emulate Keystrokes: {Escape}" id="25">
+                <Action>
+                    Window.SendKeys(u'{Escape}', False)
                 </Action>
             </Macro>
             <Macro Name="Emulate Keystrokes: {Enter}">


### PR DESCRIPTION
Fulfilling my own request #188; In EventGhost, this replaces the short-term events with enduring events.  This allows the user to have a faster key repeat when holding down a button (ie: arrow key), and also execute different actions based on length of key press.

In the if statement:
- the first case is for the initial key press
- the second case is for the key release
- the third case is for the strangely behaving STOP key, which does not trigger an initial callback with duration 0.

The demo config will repeat arrow keys at an accelerated rate, and execute Backspace or Escape based on how long the button for CEC.exit is pressed.

Tested with 2011 SONY Bravia -> 2013 Onkyo AVR -> Pulse-Eight USB-CEC Adapter -> Windows 10 + EventGhost.