### PR TITLE
Fall back to look for libudev.pc if udev.pc is not usable

### DIFF
--- a/src/libcec/cmake/CheckPlatformSupport.cmake
+++ b/src/libcec/cmake/CheckPlatformSupport.cmake
@@ -74,6 +74,10 @@ else()
 
   # udev
   pkg_check_modules(UDEV udev)
+  if (NOT UDEV_FOUND)
+    # fall back to finding libudev.pc
+    pkg_check_modules(UDEV libudev)
+  endif()
   if (UDEV_FOUND)
     set(HAVE_LIBUDEV 1)
     set(LIB_INFO "${LIB_INFO}, P8_detect")


### PR DESCRIPTION
Signed-off-by: Balint Reczey <balint@balintreczey.hu>

Tested on Debian unstable, it fixes build-time udev detection reported as:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=817051
