### PR TITLE
New adapter for the hybrid cec driver for the Odroid C2 and Wetek Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Follow the instructions in [docs/README.linux.md](docs/README.linux.md) and pass
 cmake -DHAVE_EXYNOS_API=1 ..
 ```
 
+### AOCEC
+To compile in support for AOCEC devices, you have to pass the argument -DHAVE_AOCEC_API=1 to cmake:
+```
+cmake -DHAVE_AOCEC_API=1 ..
+```
+
 ### TDA995x
 Follow the instructions in [docs/README.linux.md](docs/README.linux.md) and pass the argument -DHAVE_TDA995X_API=1 to cmake:
 ```

--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -282,6 +282,16 @@ namespace CEC {
 #define CEC_MAX_DATA_PACKET_SIZE (16 * 4)
 
 /*!
+ * the path to use for the AOCEC HDMI CEC device
+ */
+#define CEC_AOCEC_PATH		"/dev/aocec"
+
+/*!
+ * the name of the virtual COM port to use for the AOCEC' CEC wire
+ */
+#define CEC_AOCEC_VIRTUAL_COM		"AOCEC"
+
+/*!
  * Mimimum client version
  */
 #define CEC_MIN_LIB_VERSION          4
@@ -850,7 +860,8 @@ typedef enum cec_adapter_type
   ADAPTERTYPE_P8_DAUGHTERBOARD = 0x2,
   ADAPTERTYPE_RPI              = 0x100,
   ADAPTERTYPE_TDA995x          = 0x200,
-  ADAPTERTYPE_EXYNOS           = 0x300
+  ADAPTERTYPE_EXYNOS           = 0x300,
+  ADAPTERTYPE_AOCEC          = 0x500
 } cec_adapter_type;
 
 /** force exporting through swig */

--- a/src/libcec/CMakeLists.txt
+++ b/src/libcec/CMakeLists.txt
@@ -87,6 +87,9 @@ set(CEC_HEADERS devices/CECRecordingDevice.h
                 adapter/Exynos/ExynosCEC.h
                 adapter/Exynos/ExynosCECAdapterDetection.h
                 adapter/Exynos/ExynosCECAdapterCommunication.h
+                adapter/AOCEC/AOCEC.h
+                adapter/AOCEC/AOCECAdapterDetection.h
+                adapter/AOCEC/AOCECAdapterCommunication.h
                 adapter/Pulse-Eight/USBCECAdapterMessageQueue.h
                 adapter/Pulse-Eight/USBCECAdapterCommunication.h
                 adapter/Pulse-Eight/USBCECAdapterCommands.h

--- a/src/libcec/adapter/AOCEC/AOCEC.h
+++ b/src/libcec/adapter/AOCEC/AOCEC.h
@@ -1,0 +1,55 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC AOCEC Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+
+#define CEC_DEFAULT_PADDR   0x1000
+
+#define CEC_IOC_MAGIC                   'C'
+#define CEC_IOC_GET_PHYSICAL_ADDR       _IOR(CEC_IOC_MAGIC, 0x00, uint16_t)
+#define CEC_IOC_GET_VERSION             _IOR(CEC_IOC_MAGIC, 0x01, int)
+#define CEC_IOC_GET_VENDOR_ID           _IOR(CEC_IOC_MAGIC, 0x02, uint32_t)
+#define CEC_IOC_GET_PORT_INFO           _IOR(CEC_IOC_MAGIC, 0x03, int)
+#define CEC_IOC_GET_PORT_NUM            _IOR(CEC_IOC_MAGIC, 0x04, int)
+#define CEC_IOC_GET_SEND_FAIL_REASON    _IOR(CEC_IOC_MAGIC, 0x05, uint32_t)
+#define CEC_IOC_SET_OPTION_WAKEUP       _IOW(CEC_IOC_MAGIC, 0x06, uint32_t)
+#define CEC_IOC_SET_OPTION_ENALBE_CEC   _IOW(CEC_IOC_MAGIC, 0x07, uint32_t)
+#define CEC_IOC_SET_OPTION_SYS_CTRL     _IOW(CEC_IOC_MAGIC, 0x08, uint32_t)
+#define CEC_IOC_SET_OPTION_SET_LANG     _IOW(CEC_IOC_MAGIC, 0x09, uint32_t)
+#define CEC_IOC_GET_CONNECT_STATUS      _IOR(CEC_IOC_MAGIC, 0x0A, uint32_t)
+#define CEC_IOC_ADD_LOGICAL_ADDR        _IOW(CEC_IOC_MAGIC, 0x0B, uint32_t)
+#define CEC_IOC_CLR_LOGICAL_ADDR        _IOW(CEC_IOC_MAGIC, 0x0C, uint32_t)
+
+#define CEC_MAX_FRAME_SIZE  16

--- a/src/libcec/adapter/AOCEC/AOCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/AOCEC/AOCECAdapterCommunication.cpp
@@ -1,0 +1,321 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC AOCEC Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+
+#if defined(HAVE_AOCEC_API)
+#include "AOCEC.h"
+#include "AOCECAdapterCommunication.h"
+
+#include "CECTypeUtils.h"
+#include "LibCEC.h"
+#include <p8-platform/util/buffer.h>
+
+using namespace CEC;
+using namespace P8PLATFORM;
+
+#define LIB_CEC m_callback->GetLib()
+
+
+CAOCECAdapterCommunication::CAOCECAdapterCommunication(IAdapterCommunicationCallback *callback) :
+    IAdapterCommunication(callback),
+    m_bLogicalAddressChanged(false)
+{ 
+  CLockObject lock(m_mutex);
+
+  m_logicalAddresses.Clear();
+  m_fd = INVALID_SOCKET_VALUE;
+}
+
+
+CAOCECAdapterCommunication::~CAOCECAdapterCommunication(void)
+{
+  Close();
+}
+
+
+bool CAOCECAdapterCommunication::IsOpen(void)
+{
+  return IsInitialised() && m_fd != INVALID_SOCKET_VALUE;
+}
+
+
+bool CAOCECAdapterCommunication::Open(uint32_t UNUSED(iTimeoutMs), bool UNUSED(bSkipChecks), bool bStartListening)
+{
+  CLockObject lock(m_mutex);
+
+  if (IsOpen())
+    Close();
+
+  if ((m_fd = open(CEC_AOCEC_PATH, O_RDWR)) > 0)
+  {
+	uint32_t enable = true;
+
+	if (ioctl(m_fd, CEC_IOC_SET_OPTION_SYS_CTRL, enable))
+	{
+	  LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL IOCTL CEC_IOC_SET_OPTION_SYS_CTRL failed !", __func__);
+	  return false;
+	}
+
+    if (!bStartListening || CreateThread()) {
+        return true;
+    }
+    close(m_fd);
+    m_fd = INVALID_SOCKET_VALUE;
+  }
+  return false;
+}
+
+
+void CAOCECAdapterCommunication::Close(void)
+{
+  StopThread(0);
+
+  CLockObject lock(m_mutex);
+
+  uint32_t enable = false;
+
+  if (ioctl(m_fd, CEC_IOC_SET_OPTION_SYS_CTRL, enable))
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL CEC_IOC_SET_OPTION_SYS_CTRL failed !", __func__);
+  }
+
+  close(m_fd);
+  m_fd = INVALID_SOCKET_VALUE;
+}
+
+
+std::string CAOCECAdapterCommunication::GetError(void) const
+{
+  std::string strError(m_strError);
+  return strError;
+}
+
+
+cec_adapter_message_state CAOCECAdapterCommunication::Write(
+  const cec_command &data, bool &UNUSED(bRetry), uint8_t UNUSED(iLineTimeout), bool UNUSED(bIsReply))
+{
+  uint8_t buffer[CEC_MAX_FRAME_SIZE];
+  int32_t size = 1;
+  cec_adapter_message_state rc = ADAPTER_MESSAGE_STATE_SENT_NOT_ACKED;
+
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return rc;
+
+  if ((size_t)data.parameters.size + data.opcode_set > sizeof(buffer))
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: data size too large !", __func__);
+    return ADAPTER_MESSAGE_STATE_ERROR;
+  }
+ 
+  buffer[0] = (data.initiator << 4) | (data.destination & 0x0f);
+
+  if (data.opcode_set)
+  {
+    buffer[1] = data.opcode;
+    size++;
+
+    memcpy(&buffer[size], data.parameters.data, data.parameters.size);
+    size += data.parameters.size;
+  }
+
+  if (write(m_fd, (void *)buffer, size) == size)
+  {
+    rc = ADAPTER_MESSAGE_STATE_SENT_ACKED;
+  }
+  else
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: write failed !", __func__);
+  }
+
+  return rc;
+}
+
+
+uint16_t CAOCECAdapterCommunication::GetFirmwareVersion(void)
+{
+  int version = 0;
+
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return version;
+
+  if (ioctl(m_fd, CEC_IOC_GET_VERSION, &version) < 0)
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL CEC_IOC_GET_VERSION failed !", __func__);
+  }
+  return (uint16_t)version;
+}
+
+
+cec_vendor_id CAOCECAdapterCommunication::GetVendorId(void)
+{
+  int vendor_id = CEC_VENDOR_UNKNOWN;
+
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return cec_vendor_id(vendor_id);
+
+  if (ioctl(m_fd, CEC_IOC_GET_VENDOR_ID, &vendor_id) < 0)
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL CEC_IOC_GET_VENDOR_ID failed !", __func__);
+  }
+  return cec_vendor_id(vendor_id);
+}
+
+
+uint16_t CAOCECAdapterCommunication::GetPhysicalAddress(void)
+{
+  int phys_addr = CEC_DEFAULT_PADDR;
+
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return (uint16_t)phys_addr;
+
+  if (ioctl(m_fd, CEC_IOC_GET_PHYSICAL_ADDR, &phys_addr) < 0)
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL CEC_IOC_GET_PHYSICAL_ADDR failed !", __func__);
+    phys_addr = CEC_DEFAULT_PADDR;
+  }
+  return (uint16_t)phys_addr;
+}
+
+
+cec_logical_addresses CAOCECAdapterCommunication::GetLogicalAddresses(void)
+{
+  return m_logicalAddresses;
+}
+
+
+bool CAOCECAdapterCommunication::SetLogicalAddresses(const cec_logical_addresses &addresses)
+{
+  CLockObject lock(m_mutex);
+
+  unsigned int log_addr = addresses.primary;
+  if (!IsOpen())
+    return false;
+
+  if (ioctl(m_fd, CEC_IOC_ADD_LOGICAL_ADDR, log_addr))
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL CEC_IOC_ADD_LOGICAL_ADDR failed !", __func__);
+    return false;
+  }
+  m_logicalAddresses = addresses;
+  m_bLogicalAddressChanged = true;
+
+  return true;
+}
+
+
+void CAOCECAdapterCommunication::HandleLogicalAddressLost(cec_logical_address UNUSED(oldAddress))
+{
+  unsigned int log_addr = CECDEVICE_BROADCAST;
+
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return;
+
+  if (ioctl(m_fd, CEC_IOC_ADD_LOGICAL_ADDR, log_addr))
+  {
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: IOCTL CEC_IOC_ADD_LOGICAL_ADDR failed !", __func__);
+  }
+}
+
+
+void *CAOCECAdapterCommunication::Process(void)
+{
+  uint8_t buffer[CEC_MAX_FRAME_SIZE];
+  uint32_t size;
+  fd_set rfds;
+  cec_logical_address initiator, destination;
+  struct timeval tv;
+
+  if (!IsOpen())
+    return 0;
+
+  while (!IsStopped())
+  {
+    if (m_fd == INVALID_SOCKET_VALUE)
+    {
+      break;
+    }
+
+    FD_ZERO(&rfds);
+    FD_SET(m_fd, &rfds);
+
+    tv.tv_sec = 1;
+    tv.tv_usec = 0;
+
+    if (select(m_fd + 1, &rfds, NULL, NULL, &tv) >= 0 )
+    {
+
+      if (!FD_ISSET(m_fd, &rfds))
+	  continue;
+
+      size = read(m_fd, buffer, CEC_MAX_FRAME_SIZE);
+
+      if (size > 0)
+      {
+          initiator = cec_logical_address(buffer[0] >> 4);
+          destination = cec_logical_address(buffer[0] & 0x0f);
+
+          cec_command cmd;
+
+          cec_command::Format(
+            cmd, initiator, destination,
+            ( size > 1 ) ? cec_opcode(buffer[1]) : CEC_OPCODE_NONE);
+
+          for (uint8_t i = 2; i < size; i++ )
+            cmd.parameters.PushBack(buffer[i]);
+
+          if (!IsStopped())
+            m_callback->OnCommandReceived(cmd);
+      }
+    }
+  }
+
+  return 0;
+}
+
+#endif	// HAVE_AOCEC_API

--- a/src/libcec/adapter/AOCEC/AOCECAdapterCommunication.h
+++ b/src/libcec/adapter/AOCEC/AOCECAdapterCommunication.h
@@ -1,0 +1,104 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC AOCEC Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+
+#if defined(HAVE_AOCEC_API)
+
+#include <p8-platform/threads/mutex.h>
+#include <p8-platform/threads/threads.h>
+#include "../AdapterCommunication.h"
+#include <map>
+
+namespace CEC
+{
+  class CAOCECAdapterCommunication : public IAdapterCommunication, public P8PLATFORM::CThread
+  {
+  public:
+    /*!
+     * @brief Create a new AOCEC HDMI CEC communication handler.
+     * @param callback The callback to use for incoming CEC commands.
+     */
+    CAOCECAdapterCommunication(IAdapterCommunicationCallback *callback);
+    virtual ~CAOCECAdapterCommunication(void);
+
+    /** @name IAdapterCommunication implementation */
+    ///{
+    bool Open(uint32_t iTimeoutMs = CEC_DEFAULT_CONNECT_TIMEOUT, bool bSkipChecks = false, bool bStartListening = true);
+    void Close(void);
+    bool IsOpen(void);
+    std::string GetError(void) const;
+    cec_adapter_message_state Write(const cec_command &data, bool &bRetry, uint8_t iLineTimeout, bool bIsReply);
+
+    bool SetLineTimeout(uint8_t UNUSED(iTimeout)) { return true; }
+    bool StartBootloader(void) { return false; }
+    bool SetLogicalAddresses(const cec_logical_addresses &addresses);
+    cec_logical_addresses GetLogicalAddresses(void);
+    bool PingAdapter(void) { return IsInitialised(); }
+    uint16_t GetFirmwareVersion(void);
+    uint32_t GetFirmwareBuildDate(void) { return 0; }
+    bool IsRunningLatestFirmware(void) { return true; }
+    bool PersistConfiguration(const libcec_configuration & UNUSED(configuration)) { return false; }
+    bool GetConfiguration(libcec_configuration & UNUSED(configuration)) { return false; }
+    std::string GetPortName(void) { return std::string("AOCEC"); }
+    uint16_t GetPhysicalAddress(void);
+    bool SetControlledMode(bool UNUSED(controlled)) { return true; }
+    cec_vendor_id GetVendorId(void);
+    bool SupportsSourceLogicalAddress(const cec_logical_address address) { return address > CECDEVICE_TV && address <= CECDEVICE_BROADCAST; }
+    cec_adapter_type GetAdapterType(void) { return ADAPTERTYPE_AOCEC; }
+    uint16_t GetAdapterVendorId(void) const { return 1; }
+    uint16_t GetAdapterProductId(void) const { return 1; }
+    void HandleLogicalAddressLost(cec_logical_address oldAddress);
+    void SetActiveSource(bool UNUSED(bSetTo), bool UNUSED(bClientUnregistered)) {}
+    ///}
+
+    /** @name P8PLATFORM::CThread implementation */
+    ///{
+    void *Process(void);
+    ///}
+
+  private:
+    bool IsInitialised(void) const { return 1; };
+
+    std::string                 m_strError; /**< current error message */
+
+    bool                        m_bLogicalAddressChanged;
+    cec_logical_addresses       m_logicalAddresses;
+    P8PLATFORM::CMutex	        m_mutex;
+    int                         m_fd;
+  };
+};
+#endif

--- a/src/libcec/adapter/AOCEC/AOCECAdapterDetection.cpp
+++ b/src/libcec/adapter/AOCEC/AOCECAdapterDetection.cpp
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC AOCEC Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+#include <stdio.h>
+
+#if defined(HAVE_AOCEC_API)
+#include "AOCECAdapterDetection.h"
+#include "AOCEC.h"
+
+using namespace CEC;
+
+bool CAOCECAdapterDetection::FindAdapter(void)
+{
+  return access(CEC_AOCEC_PATH, 0) == 0;
+}
+
+#endif

--- a/src/libcec/adapter/AOCEC/AOCECAdapterDetection.h
+++ b/src/libcec/adapter/AOCEC/AOCECAdapterDetection.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC AOCEC Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+
+namespace CEC
+{
+  class CAOCECAdapterDetection
+  {
+  public:
+    static bool FindAdapter(void);
+  };
+}

--- a/src/libcec/adapter/AdapterFactory.cpp
+++ b/src/libcec/adapter/AdapterFactory.cpp
@@ -58,6 +58,11 @@
 #include "Exynos/ExynosCECAdapterCommunication.h"
 #endif
 
+#if defined(HAVE_AOCEC_API)
+#include "AOCEC/AOCECAdapterDetection.h"
+#include "AOCEC/AOCECAdapterCommunication.h"
+#endif
+
 using namespace CEC;
 
 int8_t CAdapterFactory::FindAdapters(cec_adapter *deviceList, uint8_t iBufSize, const char *strDevicePath /* = NULL */)
@@ -126,8 +131,20 @@ int8_t CAdapterFactory::DetectAdapters(cec_adapter_descriptor *deviceList, uint8
   }
 #endif
 
+#if defined(HAVE_AOCEC_API)
+  if (iAdaptersFound < iBufSize && CAOCECAdapterDetection::FindAdapter())
+  {
+    snprintf(deviceList[iAdaptersFound].strComPath, sizeof(deviceList[iAdaptersFound].strComPath), CEC_AOCEC_PATH);
+    snprintf(deviceList[iAdaptersFound].strComName, sizeof(deviceList[iAdaptersFound].strComName), CEC_AOCEC_VIRTUAL_COM);
+    deviceList[iAdaptersFound].iVendorId = 0;
+    deviceList[iAdaptersFound].iProductId = 0;
+    deviceList[iAdaptersFound].adapterType = ADAPTERTYPE_AOCEC;
+    iAdaptersFound++;
+  }
+#endif
 
-#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API)
+
+#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_AOCEC_API)
 #error "libCEC doesn't have support for any type of adapter. please check your build system or configuration"
 #endif
 
@@ -144,6 +161,11 @@ IAdapterCommunication *CAdapterFactory::GetInstance(const char *strPort, uint16_
 #if defined(HAVE_EXYNOS_API)
   if (!strcmp(strPort, CEC_EXYNOS_VIRTUAL_COM))
     return new CExynosCECAdapterCommunication(m_lib->m_cec);
+#endif
+
+#if defined(HAVE_AOCEC_API)
+  if (!strcmp(strPort, CEC_AOCEC_VIRTUAL_COM))
+    return new CAOCECAdapterCommunication(m_lib->m_cec);
 #endif
 
 #if defined(HAVE_RPI_API)

--- a/src/libcec/cmake/CheckPlatformSupport.cmake
+++ b/src/libcec/cmake/CheckPlatformSupport.cmake
@@ -9,6 +9,7 @@
 #       HAVE_RPI_API              ON if Raspberry Pi is supported
 #       HAVE_TDA995X_API          ON if TDA995X is supported
 #       HAVE_EXYNOS_API           ON if Exynos is supported
+#       HAVE_AOCEC_API            ON if AOCEC is supported
 #       HAVE_P8_USB               ON if Pulse-Eight devices are supported
 #       HAVE_P8_USB_DETECT        ON if Pulse-Eight devices can be auto-detected
 #       HAVE_DRM_EDID_PARSER      ON if DRM EDID parsing is supported
@@ -28,6 +29,7 @@ SET(HAVE_LIBUDEV         OFF CACHE BOOL "udev not supported")
 SET(HAVE_RPI_API         OFF CACHE BOOL "raspberry pi not supported")
 SET(HAVE_TDA995X_API     OFF CACHE BOOL "tda995x not supported")
 SET(HAVE_EXYNOS_API      OFF CACHE BOOL "exynos not supported")
+SET(HAVE_AOCEC_API       OFF CACHE BOOL "aocec not supported")
 # Pulse-Eight devices are always supported
 set(HAVE_P8_USB          ON  CACHE BOOL "p8 usb-cec supported" FORCE)
 set(HAVE_P8_USB_DETECT   OFF CACHE BOOL "p8 usb-cec detection not supported")
@@ -128,11 +130,23 @@ else()
   # Exynos
   if (${HAVE_EXYNOS_API})
     set(LIB_INFO "${LIB_INFO}, Exynos")
-    SET(HAVE_EXYNOS_API ON CACHE BOOL "exynos not supported" FORCE)
+    SET(HAVE_EXYNOS_API ON CACHE BOOL "exynos supported" FORCE)
     set(CEC_SOURCES_ADAPTER_EXYNOS adapter/Exynos/ExynosCECAdapterDetection.cpp
                                    adapter/Exynos/ExynosCECAdapterCommunication.cpp)
     source_group("Source Files\\adapter\\Exynos" FILES ${CEC_SOURCES_ADAPTER_EXYNOS})
     list(APPEND CEC_SOURCES ${CEC_SOURCES_ADAPTER_EXYNOS})
+  endif()
+
+  # AOCEC
+  if (${HAVE_AOCEC_API})
+    set(LIB_INFO "${LIB_INFO}, AOCEC")
+    SET(HAVE_AOCEC_API ON CACHE BOOL "AOCEC supported" FORCE)
+    set(CEC_SOURCES_ADAPTER_AOCEC adapter/AOCEC/AOCECAdapterDetection.cpp
+                                   adapter/AOCEC/AOCECAdapterCommunication.cpp)
+    source_group("Source Files\\adapter\\AOCEC" FILES ${CEC_SOURCES_ADAPTER_AOCEC})
+    list(APPEND CEC_SOURCES ${CEC_SOURCES_ADAPTER_AOCEC})
+  else()
+    set(HAVE_AOCEC_API 0)
   endif()
 endif()
 

--- a/src/libcec/cmake/DisplayPlatformSupport.cmake
+++ b/src/libcec/cmake/DisplayPlatformSupport.cmake
@@ -44,6 +44,12 @@ else()
   message(STATUS "DRM support:                            no")
 endif()
 
+if (HAVE_AOCEC_API)
+  message(STATUS "AOCEC support:                        yes")
+else()
+  message(STATUS "AOCEC support:                        no")
+endif()
+
 if (HAVE_PYTHON)
   message(STATUS "Python support:                         version ${PYTHONLIBS_VERSION_STRING} (${PYTHON_VERSION})")
 else()

--- a/src/libcec/env.h.in
+++ b/src/libcec/env.h.in
@@ -72,6 +72,9 @@
 /* Define to 1 for Exynos support */
 #cmakedefine HAVE_EXYNOS_API @HAVE_EXYNOS_API@
 
+/* Define to 1 for AOCEC support */
+#cmakedefine HAVE_AOCEC_API @HAVE_AOCEC_API@
+
 /* Define to 1 for nVidia EDID parsing support (on selected models) */
 #cmakedefine HAVE_NVIDIA_EDID_PARSER @HAVE_NVIDIA_EDID_PARSER@
 


### PR DESCRIPTION
This adapter is needed for the new hybrid cec driver for the Odroid C2 made by @raybuntu:
[https://github.com/hardkernel/linux/compare/odroidc2-3.14.y...Raybuntu:hdmi_ao_cec](url)
It might be possible that his driver and this adapter just work with other devices that uses an Amlogic S905 SOC, but raybuntu and me have no access to other devices currently.

@opdenkamp, please, find the time, it is not much code. It contains at least one error less than the exynos adapter you already accepted. It works!

