### PR TITLE
break on first valid drm edid

### DIFF
--- a/src/libcec/platform/drm/drm-edid.cpp
+++ b/src/libcec/platform/drm/drm-edid.cpp
@@ -59,7 +59,7 @@ uint16_t CDRMEdidParser::GetPhysicalAddress(void)
   std::string enablededid;
   std::string line;
 
-  while (entry != NULL)
+  while (entry != NULL && enablededid.empty())
   {
     // We look if the element is a symlinl
     if (entry->d_type == DT_LNK)


### PR DESCRIPTION
On my ASUS Q87T the current version fails with a SEGFAULT. My guest is, that there is an invalid assumption about the directory structure an content - however the early break fixes the bug.
