### PR TITLE
Amlogic CEC adapter for Meson 6 and Meson 8(b)

### DIFF
--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -276,6 +276,16 @@ namespace CEC {
  */
 #define CEC_EXYNOS_VIRTUAL_COM		"Exynos"
 
+/*!
+ * the path to use for the Amlogic HDMI CEC device
+ */
+#define CEC_AMLOGIC_PATH               "/dev/AmlogicCEC"
+
+/*!
+ * the name of the virtual COM port to use for the AMLOGIC' CEC wire
+ */
+#define CEC_AMLOGIC_VIRTUAL_COM                "Amlogic"
+
 /**
  * Maximum size of a data packet
  */
@@ -861,7 +871,8 @@ typedef enum cec_adapter_type
   ADAPTERTYPE_RPI              = 0x100,
   ADAPTERTYPE_TDA995x          = 0x200,
   ADAPTERTYPE_EXYNOS           = 0x300,
-  ADAPTERTYPE_AOCEC            = 0x500
+  ADAPTERTYPE_AOCEC            = 0x500,
+  ADAPTERTYPE_AMLOGIC          = 0x600
 } cec_adapter_type;
 
 /** force exporting through swig */

--- a/src/libcec/CMakeLists.txt
+++ b/src/libcec/CMakeLists.txt
@@ -87,6 +87,9 @@ set(CEC_HEADERS devices/CECRecordingDevice.h
                 adapter/Exynos/ExynosCEC.h
                 adapter/Exynos/ExynosCECAdapterDetection.h
                 adapter/Exynos/ExynosCECAdapterCommunication.h
+		adapter/Amlogic/AmlogicCEC.h
+                adapter/Amlogic/AmlogicCECAdapterDetection.h
+                adapter/Amlogic/AmlogicCECAdapterCommunication.h
                 adapter/AOCEC/AOCEC.h
                 adapter/AOCEC/AOCECAdapterDetection.h
                 adapter/AOCEC/AOCECAdapterCommunication.h

--- a/src/libcec/adapter/AdapterFactory.cpp
+++ b/src/libcec/adapter/AdapterFactory.cpp
@@ -58,6 +58,11 @@
 #include "Exynos/ExynosCECAdapterCommunication.h"
 #endif
 
+#if defined(HAVE_AMLOGIC_API)
+#include "Amlogic/AmlogicCECAdapterDetection.h"
+#include "Amlogic/AmlogicCECAdapterCommunication.h"
+#endif
+
 #if defined(HAVE_AOCEC_API)
 #include "AOCEC/AOCECAdapterDetection.h"
 #include "AOCEC/AOCECAdapterCommunication.h"
@@ -143,6 +148,18 @@ int8_t CAdapterFactory::DetectAdapters(cec_adapter_descriptor *deviceList, uint8
   }
 #endif
 
+#if defined(HAVE_AMLOGIC_API)
+  if (iAdaptersFound < iBufSize && CAmlogicCECAdapterDetection::FindAdapter())
+  {
+    snprintf(deviceList[iAdaptersFound].strComPath, sizeof(deviceList[iAdaptersFound].strComPath), CEC_AMLOGIC_PATH);
+    snprintf(deviceList[iAdaptersFound].strComName, sizeof(deviceList[iAdaptersFound].strComName), CEC_AMLOGIC_VIRTUAL_COM);
+    deviceList[iAdaptersFound].iVendorId = 0;
+    deviceList[iAdaptersFound].iProductId = 0;
+    deviceList[iAdaptersFound].adapterType = ADAPTERTYPE_AMLOGIC;
+    iAdaptersFound++;
+  }
+#endif
+
 
 #if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_AOCEC_API)
 #error "libCEC doesn't have support for any type of adapter. please check your build system or configuration"
@@ -173,11 +190,16 @@ IAdapterCommunication *CAdapterFactory::GetInstance(const char *strPort, uint16_
     return new CRPiCECAdapterCommunication(m_lib->m_cec);
 #endif
 
+#if defined(HAVE_AMLOGIC_API)
+  if (!strcmp(strPort, CEC_AMLOGIC_VIRTUAL_COM))
+    return new CAmlogicCECAdapterCommunication(m_lib->m_cec);
+#endif
+
 #if defined(HAVE_P8_USB)
   return new CUSBCECAdapterCommunication(m_lib->m_cec, strPort, iBaudRate);
 #endif
 
-#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API)
+#if !defined(HAVE_RPI_API) && !defined(HAVE_P8_USB) && !defined(HAVE_TDA995X_API) && !defined(HAVE_EXYNOS_API) && !defined(HAVE_AMLOGIC_API)
   return NULL;
 #endif
 }

--- a/src/libcec/adapter/Amlogic/AmlogicCEC.h
+++ b/src/libcec/adapter/Amlogic/AmlogicCEC.h
@@ -1,0 +1,40 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Amlogic Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+
+#define CEC_IOC_SETLADDR    _IOW('c', 0, unsigned int)
+#define CEC_IOC_GETPADDR    _IO('c', 1)
+#define CEC_MAX_FRAME_SIZE  16

--- a/src/libcec/adapter/Amlogic/AmlogicCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/Amlogic/AmlogicCECAdapterCommunication.cpp
@@ -1,0 +1,285 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Amlogic Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+
+#if defined(HAVE_AMLOGIC_API)
+#include "AmlogicCEC.h"
+#include "AmlogicCECAdapterCommunication.h"
+
+#include "CECTypeUtils.h"
+#include "LibCEC.h"
+#include <p8-platform/util/buffer.h>
+
+using namespace CEC;
+using namespace P8PLATFORM;
+
+#define LIB_CEC m_callback->GetLib()
+
+
+CAmlogicCECAdapterCommunication::CAmlogicCECAdapterCommunication(IAdapterCommunicationCallback *callback) :
+    IAdapterCommunication(callback),
+    m_bLogicalAddressChanged(false)
+{
+  CLockObject lock(m_mutex);
+
+  m_logicalAddresses.Clear();
+  m_fd = INVALID_SOCKET_VALUE;
+}
+
+CAmlogicCECAdapterCommunication::~CAmlogicCECAdapterCommunication(void)
+{
+  Close();
+}
+
+bool CAmlogicCECAdapterCommunication::IsOpen(void)
+{
+  CLockObject lock(m_mutex);
+  return IsInitialised() && m_fd != INVALID_SOCKET_VALUE;
+}
+
+bool CAmlogicCECAdapterCommunication::Open(uint32_t UNUSED(iTimeoutMs), bool UNUSED(bSkipChecks), bool bStartListening)
+{
+  CLockObject lock(m_mutex);
+
+  if (IsOpen())
+    Close();
+
+  if ((m_fd = open(CEC_AMLOGIC_PATH, O_RDWR)) > 0)
+  {
+    if (!bStartListening || CreateThread()) {
+        return true;
+    }
+    close(m_fd);
+    m_fd = INVALID_SOCKET_VALUE;
+  }
+  return false;
+}
+
+void CAmlogicCECAdapterCommunication::Close(void)
+{
+  StopThread(0);
+
+  CLockObject lock(m_mutex);
+
+  close(m_fd);
+  m_fd = INVALID_SOCKET_VALUE;
+}
+
+std::string CAmlogicCECAdapterCommunication::GetError(void) const
+{
+  std::string strError(m_strError);
+  return strError;
+}
+
+cec_adapter_message_state CAmlogicCECAdapterCommunication::Write(
+  const cec_command &data, bool &UNUSED(bRetry), uint8_t UNUSED(iLineTimeout), bool UNUSED(bIsReply))
+{
+  uint8_t buffer[CEC_MAX_FRAME_SIZE];
+  int32_t size = 1;
+  cec_adapter_message_state rc = ADAPTER_MESSAGE_STATE_SENT_NOT_ACKED;
+
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return rc;
+
+  if ((size_t)data.parameters.size + data.opcode_set > sizeof(buffer))
+  {
+    LIB_CEC->AddLog(CEC_LOG_WARNING, "%s: buffer too small for data", __func__);
+    return ADAPTER_MESSAGE_STATE_ERROR;
+  }
+
+  buffer[0] = (data.initiator << 4) | (data.destination & 0x0f);
+
+  if (data.opcode_set)
+  {
+    buffer[1] = data.opcode;
+    size++;
+
+    memcpy(&buffer[size], data.parameters.data, data.parameters.size);
+    size += data.parameters.size;
+  }
+
+  if (write(m_fd, (void *)buffer, size) == size)
+  {
+    rc = ADAPTER_MESSAGE_STATE_SENT_ACKED;
+  }
+  else
+  {
+    LIB_CEC->AddLog(CEC_LOG_WARNING, "%s: write failed",  __func__);
+  }
+
+  return rc;
+}
+
+uint16_t CAmlogicCECAdapterCommunication::GetFirmwareVersion(void)
+{
+  return 0;
+}
+
+cec_vendor_id CAmlogicCECAdapterCommunication::GetVendorId(void)
+{
+  return cec_vendor_id(CEC_VENDOR_UNKNOWN);
+}
+
+uint16_t CAmlogicCECAdapterCommunication::GetPhysicalAddress(void)
+{
+  int phys_addr = CEC_INVALID_PHYSICAL_ADDRESS;
+
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return (uint16_t)phys_addr;
+
+  if ((phys_addr = ioctl(m_fd, CEC_IOC_GETPADDR)) < 0)
+  {
+    LIB_CEC->AddLog(CEC_LOG_WARNING, "%s: ioctl(CEC_IOC_GETPADDR) failed", __func__);
+    phys_addr = CEC_INVALID_PHYSICAL_ADDRESS;
+  }
+  return (uint16_t)phys_addr;
+}
+
+cec_logical_addresses CAmlogicCECAdapterCommunication::GetLogicalAddresses(void)
+{
+  CLockObject lock(m_mutex);
+  return m_logicalAddresses;
+}
+
+bool CAmlogicCECAdapterCommunication::SetLogicalAddresses(const cec_logical_addresses &addresses)
+{
+  CLockObject lock(m_mutex);
+
+  unsigned int log_addr = addresses.primary;
+
+  if (!IsOpen())
+    return false;
+
+  if (ioctl(m_fd, CEC_IOC_SETLADDR, &log_addr))
+  {
+    LIB_CEC->AddLog(CEC_LOG_WARNING, "%s: ioctl(CEC_IOC_SETLADDR) failed", __func__);
+    return false;
+  }
+  m_logicalAddresses = addresses;
+  m_bLogicalAddressChanged = true;
+
+  return true;
+}
+
+void CAmlogicCECAdapterCommunication::HandleLogicalAddressLost(cec_logical_address UNUSED(oldAddress))
+{
+  unsigned int log_addr = CECDEVICE_BROADCAST;
+
+  CLockObject lock(m_mutex);
+
+  if (!IsOpen())
+    return;
+
+  if (ioctl(m_fd, CEC_IOC_SETLADDR, &log_addr))
+  {
+    LIB_CEC->AddLog(CEC_LOG_WARNING, "%s: ioctl(CEC_IOC_SETLADDR) failed", __func__);
+  }
+}
+
+void *CAmlogicCECAdapterCommunication::Process(void)
+{
+  uint8_t buffer[CEC_MAX_FRAME_SIZE];
+  uint32_t size;
+  fd_set rfds;
+  cec_logical_address initiator, destination;
+  struct timeval tv;
+
+  if (!IsOpen())
+    return 0;
+
+  while (!IsStopped())
+  {
+    if (m_fd == INVALID_SOCKET_VALUE)
+    {
+      Sleep(250);
+      continue;
+    }
+
+    FD_ZERO(&rfds);
+    FD_SET(m_fd, &rfds);
+
+    tv.tv_sec = 1;
+    tv.tv_usec = 0;
+
+    if (select(m_fd + 1, &rfds, NULL, NULL, &tv) >= 0 )
+    {
+
+      if (!FD_ISSET(m_fd, &rfds))
+	  continue;
+
+      size = read(m_fd, buffer, CEC_MAX_FRAME_SIZE);
+
+      if (size > 0)
+      {
+          if (buffer[0] == 0xff) // driver wants us to reread the physical address
+          {
+              if (!IsStopped())
+              {
+                  uint16_t iNewAddress = GetPhysicalAddress();
+                  m_callback->HandlePhysicalAddressChanged(iNewAddress);
+              }
+              continue;
+          }
+
+          initiator = cec_logical_address(buffer[0] >> 4);
+          destination = cec_logical_address(buffer[0] & 0x0f);
+
+          cec_command cmd;
+
+          cec_command::Format(
+            cmd, initiator, destination,
+            ( size > 1 ) ? cec_opcode(buffer[1]) : CEC_OPCODE_NONE);
+
+          for( uint8_t i = 2; i < size; i++ )
+            cmd.parameters.PushBack(buffer[i]);
+
+          if (!IsStopped())
+            m_callback->OnCommandReceived(cmd);
+      }
+    }
+  }
+
+  return 0;
+}
+
+#endif	// HAVE_AMLOGIC_API

--- a/src/libcec/adapter/Amlogic/AmlogicCECAdapterCommunication.h
+++ b/src/libcec/adapter/Amlogic/AmlogicCECAdapterCommunication.h
@@ -1,0 +1,104 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Amlogic Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+
+#if defined(HAVE_AMLOGIC_API)
+
+#include <p8-platform/threads/mutex.h>
+#include <p8-platform/threads/threads.h>
+#include "../AdapterCommunication.h"
+#include <map>
+
+namespace CEC
+{
+  class CAmlogicCECAdapterCommunication : public IAdapterCommunication, public P8PLATFORM::CThread
+  {
+  public:
+    /*!
+     * @brief Create a new Exynos HDMI CEC communication handler.
+     * @param callback The callback to use for incoming CEC commands.
+     */
+    CAmlogicCECAdapterCommunication(IAdapterCommunicationCallback *callback);
+    virtual ~CAmlogicCECAdapterCommunication(void);
+
+    /** @name IAdapterCommunication implementation */
+    ///{
+    bool Open(uint32_t iTimeoutMs = CEC_DEFAULT_CONNECT_TIMEOUT, bool bSkipChecks = false, bool bStartListening = true);
+    void Close(void);
+    bool IsOpen(void);
+    std::string GetError(void) const;
+    cec_adapter_message_state Write(const cec_command &data, bool &bRetry, uint8_t iLineTimeout, bool bIsReply);
+
+    bool SetLineTimeout(uint8_t UNUSED(iTimeout)) { return true; }
+    bool StartBootloader(void) { return false; }
+    bool SetLogicalAddresses(const cec_logical_addresses &addresses);
+    cec_logical_addresses GetLogicalAddresses(void);
+    bool PingAdapter(void) { return IsInitialised(); }
+    uint16_t GetFirmwareVersion(void);
+    uint32_t GetFirmwareBuildDate(void) { return 0; }
+    bool IsRunningLatestFirmware(void) { return true; }
+    bool PersistConfiguration(const libcec_configuration & UNUSED(configuration)) { return false; }
+    bool GetConfiguration(libcec_configuration & UNUSED(configuration)) { return false; }
+    std::string GetPortName(void) { return std::string("AMLOGIC"); }
+    uint16_t GetPhysicalAddress(void);
+    bool SetControlledMode(bool UNUSED(controlled)) { return true; }
+    cec_vendor_id GetVendorId(void);
+    bool SupportsSourceLogicalAddress(const cec_logical_address address) { return address > CECDEVICE_TV && address <= CECDEVICE_BROADCAST; }
+    cec_adapter_type GetAdapterType(void) { return ADAPTERTYPE_AMLOGIC; }
+    uint16_t GetAdapterVendorId(void) const { return 1; }
+    uint16_t GetAdapterProductId(void) const { return 1; }
+    void HandleLogicalAddressLost(cec_logical_address oldAddress);
+    void SetActiveSource(bool UNUSED(bSetTo), bool UNUSED(bClientUnregistered)) {}
+    ///}
+
+    /** @name P8PLATFORM::CThread implementation */
+    ///{
+    void *Process(void);
+    ///}
+
+  private:
+    bool IsInitialised(void) const { return 1; };
+
+    std::string                 m_strError; /**< current error message */
+
+    bool                        m_bLogicalAddressChanged;
+    cec_logical_addresses       m_logicalAddresses;
+    P8PLATFORM::CMutex	        m_mutex;
+    int                         m_fd;
+  };
+};
+#endif

--- a/src/libcec/adapter/Amlogic/AmlogicCECAdapterDetection.cpp
+++ b/src/libcec/adapter/Amlogic/AmlogicCECAdapterDetection.cpp
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Amlogic Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+#include <stdio.h>
+
+#if defined(HAVE_AMLOGIC_API)
+#include "AmlogicCECAdapterDetection.h"
+#include "AmlogicCEC.h"
+
+using namespace CEC;
+
+bool CAmlogicCECAdapterDetection::FindAdapter(void)
+{
+  return access(CEC_AMLOGIC_PATH, 0) == 0;
+}
+
+#endif

--- a/src/libcec/adapter/Amlogic/AmlogicCECAdapterDetection.h
+++ b/src/libcec/adapter/Amlogic/AmlogicCECAdapterDetection.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC Amlogic Code Copyright (C) 2016 Gerald Dachs
+ * based heavily on:
+ * libCEC Exynos Code Copyright (C) 2014 Valentin Manea
+ * libCEC(R) is Copyright (C) 2011-2015 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+
+namespace CEC
+{
+  class CAmlogicCECAdapterDetection
+  {
+  public:
+    static bool FindAdapter(void);
+  };
+}

--- a/src/libcec/cmake/CheckPlatformSupport.cmake
+++ b/src/libcec/cmake/CheckPlatformSupport.cmake
@@ -11,6 +11,7 @@
 #       HAVE_EXYNOS_API           ON if Exynos is supported
 #       HAVE_AOCEC_API            ON if AOCEC is supported
 #       HAVE_P8_USB               ON if Pulse-Eight devices are supported
+#      HAVE_AMLOGIC_API          1 if AMLOGIC is supported
 #       HAVE_P8_USB_DETECT        ON if Pulse-Eight devices can be auto-detected
 #       HAVE_DRM_EDID_PARSER      ON if DRM EDID parsing is supported
 #
@@ -30,6 +31,7 @@ SET(HAVE_RPI_API         OFF CACHE BOOL "raspberry pi not supported")
 SET(HAVE_TDA995X_API     OFF CACHE BOOL "tda995x not supported")
 SET(HAVE_EXYNOS_API      OFF CACHE BOOL "exynos not supported")
 SET(HAVE_AOCEC_API       OFF CACHE BOOL "aocec not supported")
+SET(HAVE_AMLOGIC_API     OFF CACHE BOOL "amlogic not supported")
 # Pulse-Eight devices are always supported
 set(HAVE_P8_USB          ON  CACHE BOOL "p8 usb-cec supported" FORCE)
 set(HAVE_P8_USB_DETECT   OFF CACHE BOOL "p8 usb-cec detection not supported")
@@ -135,6 +137,18 @@ else()
                                    adapter/Exynos/ExynosCECAdapterCommunication.cpp)
     source_group("Source Files\\adapter\\Exynos" FILES ${CEC_SOURCES_ADAPTER_EXYNOS})
     list(APPEND CEC_SOURCES ${CEC_SOURCES_ADAPTER_EXYNOS})
+  endif()
+
+  # Amlogic
+  if (${HAVE_AMLOGIC_API})
+    set(LIB_INFO "${LIB_INFO}, Amlogic")
+    set(HAVE_AMLOGIC_API ON CACHE BOOL "Amlogic supported" FORCE)
+    set(CEC_SOURCES_ADAPTER_AMLOGIC adapter/Amlogic/AmlogicCECAdapterDetection.cpp
+                                   adapter/Amlogic/AmlogicCECAdapterCommunication.cpp)
+    source_group("Source Files\\adapter\\Amlogic" FILES ${CEC_SOURCES_ADAPTER_AMLOGIC})
+    list(APPEND CEC_SOURCES ${CEC_SOURCES_ADAPTER_AMLOGIC})
+  else()
+    set(HAVE_AMLOGIC_API 0)
   endif()
 
   # AOCEC

--- a/src/libcec/cmake/DisplayPlatformSupport.cmake
+++ b/src/libcec/cmake/DisplayPlatformSupport.cmake
@@ -56,5 +56,11 @@ else()
   message(STATUS "Python support:                         no")
 endif()
 
+if (HAVE_AMLOGIC_API)
+  message(STATUS "Amlogic support:                        yes")
+else()
+  message(STATUS "Amlogic support:                        no")
+endif()
+
 message(STATUS "lib info: ${LIB_INFO}")
 

--- a/src/libcec/env.h.in
+++ b/src/libcec/env.h.in
@@ -78,6 +78,9 @@
 /* Define to 1 for nVidia EDID parsing support (on selected models) */
 #cmakedefine HAVE_NVIDIA_EDID_PARSER @HAVE_NVIDIA_EDID_PARSER@
 
+/* Define to 1 for Amlogic support */
+#cmakedefine HAVE_AMLOGIC_API @HAVE_AMLOGIC_API@
+
 /* Define to 1 for DRM EDID parsing support */
 #cmakedefine HAVE_DRM_EDID_PARSER @HAVE_DRM_EDID_PARSER@
 


### PR DESCRIPTION
Refreshed Amlogic adapter for Meson 6 and Meson 8(b) with the help of @kszaq. Made the same changes that the AOCEC driver got before inclusion. Tested with Wetek Core and Wetek Play with LibreELEC. Should work for Odroid C1(+) too.