### PR TITLE
Install pkgconfig in arch-specific dir

### DIFF
--- a/src/libcec/CMakeLists.txt
+++ b/src/libcec/CMakeLists.txt
@@ -164,7 +164,7 @@ else()
                         ${CMAKE_INSTALL_PREFIX}/include)
 
   install(FILES         ${CMAKE_CURRENT_SOURCE_DIR}/libcec.pc
-          DESTINATION   ${CMAKE_INSTALL_LIBDIR_NOARCH}/pkgconfig)
+          DESTINATION   ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 # install headers


### PR DESCRIPTION
As .pc file contains architecture-specific information, it should be installed in ${CMAKE_INSTALL_LIBDIR} instead of ${CMAKE_INSTALL_LIBDIR_NOARCH}.