### PR TITLE
Install Python demo as executable

### DIFF
--- a/src/pyCecClient/CMakeLists.txt
+++ b/src/pyCecClient/CMakeLists.txt
@@ -7,10 +7,11 @@ find_package(PythonLibs)
 
 if (PYTHONLIBS_FOUND)
   if (WIN32)
-    install(FILES pyCecClient.py
+    install(PROGRAMS pyCecClient.py
             DESTINATION python/.)
   else()
-    install(FILES pyCecClient.py
-            DESTINATION bin/.)
+    install(PROGRAMS pyCecClient.py
+            DESTINATION bin/.
+            RENAME pyCecClient)
   endif()
 endif()


### PR DESCRIPTION
On non-Windows platforms install without extension

----

As it's going in bin suggest it should be executable - it is in the repository but CMake is removing it.

My preference is not to use file extensions on Linux, happy to remove the RENAME from the patch if not OK.

Have only tested on Linux.