### PR TITLE
Correct installation of python bindings

### DIFF
--- a/src/libcec/cmake/CheckPlatformSupport.cmake
+++ b/src/libcec/cmake/CheckPlatformSupport.cmake
@@ -195,9 +195,9 @@ else()
               RENAME      __init__.py)
     else()
       install(TARGETS     ${SWIG_MODULE_cec_REAL_NAME}
-              DESTINATION lib/python${PYTHON_VERSION}/dist-packages/cec)
+              DESTINATION lib/python${PYTHON_VERSION}/site-packages/cec)
       install(FILES       ${CMAKE_BINARY_DIR}/src/libcec/cec.py
-              DESTINATION lib/python${PYTHON_VERSION}/dist-packages/cec
+              DESTINATION lib/python${PYTHON_VERSION}/site-packages/cec
               RENAME      __init__.py)
     endif()
   endif()


### PR DESCRIPTION
dist-packages is a Debian-specific directory for distribution packages (and used in derivatives such as Ubuntu). Therefore changed to site-packages.