### PR TITLE
Use CMAKE_INSTALL_LIBDIR instead of lib

### DIFF
--- a/src/libcec/cmake/CheckPlatformSupport.cmake
+++ b/src/libcec/cmake/CheckPlatformSupport.cmake
@@ -200,9 +200,9 @@ else()
         SET(PYTHON_PKG_DIR "site-packages")
       endif()
       install(TARGETS     ${SWIG_MODULE_cec_REAL_NAME}
-              DESTINATION lib/python${PYTHON_VERSION}/${PYTHON_PKG_DIR}/cec)
+              DESTINATION ${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION}/${PYTHON_PKG_DIR}/cec)
       install(FILES       ${CMAKE_BINARY_DIR}/src/libcec/cec.py
-              DESTINATION lib/python${PYTHON_VERSION}/${PYTHON_PKG_DIR}/cec
+              DESTINATION ${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION}/${PYTHON_PKG_DIR}/cec
               RENAME      __init__.py)
     endif()
   endif()


### PR DESCRIPTION
I think you should use ${CMAKE_INSTALL_LIBDIR} variable instead of plain 'lib', because the shared library which is installed is arch specific and should be install to the right /usr/lib{,64} directory