### PR TITLE
fix missing tinfo linking in cec-client

### DIFF
--- a/src/cec-client/CMakeLists.txt
+++ b/src/cec-client/CMakeLists.txt
@@ -44,6 +44,7 @@ if (NOT WIN32)
   # curses
   if (HAVE_CURSES_API)
     target_link_libraries(cec-client curses)
+    target_link_libraries(cec-client tinfo)
   endif()
 
   # rt


### PR DESCRIPTION
Hi, mudler from Gentoo/Sabayon.

While compiling libcec 4.0.1 in Gentoo i had the following error

```
[ 97%] Linking CXX executable cec-client
/usr/bin/x86_64-pc-linux-gnu-g++   -O2 -march=x86-64 -pipe -std=c++11  -lm CMakeFiles/cec-client.dir/cec-client.cpp.o CMakeFiles/cec-client.dir/curses/CursesControl.cpp.o  -o cec-client-4.0.1 -rdynamic -L/usr/lib64 -lp8-platform -lpthread -lpthread -ldl -lcurses -lrt
/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/cec-client.dir/curses/CursesControl.cpp.o: undefined reference to symbol 'keypad'
/lib64/libtinfo.so.6: error adding symbols: DSO missing from command line

```
The patch fixed it, if i'm correct the problem is there since version 4