### PR TITLE
Fix menu language string

### DIFF
--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -133,7 +133,7 @@ bool CCECClient::OnRegister(void)
       (*it)->SetOSDName(m_configuration.strDeviceName);
 
     // set the default menu language for devices we control
-    (*it)->SetMenuLanguage(m_configuration.strDeviceLanguage);
+    (*it)->SetMenuLanguage(std::string(m_configuration.strDeviceLanguage, 3));
   }
 
   // set the physical address


### PR DESCRIPTION
Since _strDeviceLanguage_ in _struct libcec_configuration_ is not zero-terminated, limit the length to avoid garbage in log files.
