### PR TITLE
Prevent AOCEC adapter from stopping without warning

### DIFF
--- a/src/libcec/adapter/AOCEC/AOCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/AOCEC/AOCECAdapterCommunication.cpp
@@ -265,7 +265,8 @@ void *CAOCECAdapterCommunication::Process(void)
   {
     if (m_fd == INVALID_SOCKET_VALUE)
     {
-      break;
+      Sleep(250);
+      continue;
     }
 
     FD_ZERO(&rfds);


### PR DESCRIPTION
If file descriptor is invalid, wait for it to be valid and don't stop
libcec with no message. Make it wait for valid file descriptor.