### PR TITLE
Include C version of libCEC loader when installing

### DIFF
--- a/src/libcec/CMakeLists.txt
+++ b/src/libcec/CMakeLists.txt
@@ -75,6 +75,7 @@ set(CEC_SOURCES_PLATFORM platform/adl/adl-edid.cpp
 set(CEC_EXT_HEADERS ${PROJECT_SOURCE_DIR}/../../include/cec.h
                     ${PROJECT_SOURCE_DIR}/../../include/cecc.h
                     ${PROJECT_SOURCE_DIR}/../../include/cecloader.h
+                    ${PROJECT_SOURCE_DIR}/../../include/ceccloader.h
                     ${PROJECT_SOURCE_DIR}/../../include/cectypes.h
                     ${PROJECT_SOURCE_DIR}/../../include/version.h)
 source_group("Header Files (external)" FILES ${CEC_EXT_HEADERS})
@@ -172,6 +173,7 @@ endif()
 install(FILES ${PROJECT_SOURCE_DIR}/../../include/cec.h
               ${PROJECT_SOURCE_DIR}/../../include/cecc.h
               ${PROJECT_SOURCE_DIR}/../../include/cecloader.h
+              ${PROJECT_SOURCE_DIR}/../../include/ceccloader.h
               ${PROJECT_SOURCE_DIR}/../../include/cectypes.h
               ${PROJECT_SOURCE_DIR}/../../include/version.h
         DESTINATION include/libcec)


### PR DESCRIPTION
Currently, ceccloader.h is not part of the default install of libcec, so users wishing to compile against the C API instead of the C++ API must download ceccloader.h separately. This PR adds ceccloader.h to the EXT_HEADERS and install section so that the C version of the libcec loader will be installed to $(PREFIX)include/libcec alongside cecloader.h, etc. 