### PR TITLE
Fix build if tinfo library is not present.

### DIFF
--- a/src/cec-client/CMakeLists.txt
+++ b/src/cec-client/CMakeLists.txt
@@ -27,7 +27,11 @@ set(cecclient_SOURCES cec-client.cpp)
 check_library_exists(curses initscr "" HAVE_CURSES_API)
 if (HAVE_CURSES_API)
   list(APPEND cecclient_SOURCES curses/CursesControl.cpp)
+
+  # tinfo
+  find_library(HAVE_CURSES_TINFO tinfo)
 endif()
+
 
 add_executable(cec-client ${cecclient_SOURCES})
 set_target_properties(cec-client PROPERTIES VERSION ${LIBCEC_VERSION_MAJOR}.${LIBCEC_VERSION_MINOR}.${LIBCEC_VERSION_PATCH})
@@ -44,7 +48,9 @@ if (NOT WIN32)
   # curses
   if (HAVE_CURSES_API)
     target_link_libraries(cec-client curses)
-    target_link_libraries(cec-client tinfo)
+    if (HAVE_CURSES_TINFO)
+      target_link_libraries(cec-client tinfo)
+    endif()
   endif()
 
   # rt


### PR DESCRIPTION
NCurses supports both having tinfo included or separate, so we need to check for both conditions. If we specify tinfo when it is not present, we get a linker error.

Gentoo-Bug: https://bugs.gentoo.org/615634