### PR TITLE
Explicitly use python3 in pyCecClient

### DIFF
--- a/src/pyCecClient/pyCecClient.py
+++ b/src/pyCecClient/pyCecClient.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python3
 ## demo of the python-libcec API
 
 # This file is part of the libCEC(R) library.


### PR DESCRIPTION
This makes it clear that python3 is required and not python2.