### PR TITLE
Fix Pulse-Eight USB CEC adapter detection on macOS Mojave

### DIFF
--- a/src/libcec/adapter/Pulse-Eight/USBCECAdapterDetection.cpp
+++ b/src/libcec/adapter/Pulse-Eight/USBCECAdapterDetection.cpp
@@ -270,7 +270,7 @@ uint8_t CUSBCECAdapterDetection::FindAdaptersApple(cec_adapter_descriptor *devic
   CFMutableDictionaryRef classesToMatch = IOServiceMatching(kIOSerialBSDServiceValue);
   if (classesToMatch)
   {
-    CFDictionarySetValue(classesToMatch, CFSTR(kIOSerialBSDTypeKey), CFSTR(kIOSerialBSDModemType));
+    CFDictionarySetValue(classesToMatch, CFSTR(kIOSerialBSDTypeKey), CFSTR(kIOSerialBSDAllTypes));
     kresult = IOServiceGetMatchingServices(kIOMasterPortDefault, classesToMatch, &serialPortIterator);
     if (kresult == KERN_SUCCESS)
     {


### PR DESCRIPTION
In macOS Mojave the Pulse-Eight USB CEC adapter is presented as RS232 type instead of modem type as in previous macOS versions (see attached screenshot). This breaks adapter detection code in libcec. Changing the type to "kIOSerialBSDRS232Type" fixes the issue for macOS Mojave but probably breaks it on previous versions. Changing it to "kIOSerialBSDAllTypes" works on Mojave & should also work on previous versions of macOS.

![screenshot 2018-10-02 at 23 26 50](https://user-images.githubusercontent.com/133844/46378245-47b3db00-c69b-11e8-9efd-0d5e3f5e9a3e.png)

This fixes https://github.com/Pulse-Eight/libcec/issues/432