### PR TITLE
Fix raw_input not defined

### DIFF
--- a/src/pyCecClient/pyCecClient.py
+++ b/src/pyCecClient/pyCecClient.py
@@ -149,7 +149,7 @@ class pyCecClient:
   def MainLoop(self):
     runLoop = True
     while runLoop:
-      command = raw_input("Enter command:").lower()
+      command = input("Enter command:").lower()
       if command == 'q' or command == 'quit':
         runLoop = False
       elif command == 'self':


### PR DESCRIPTION
`raw_input` was renamed to `input` in Python 3. Also, should close #440.