### PR TITLE
Update README.md with link to Skull Canyon and Hades Canyon NUC adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # About
 This library provides support for Pulse-Eight's USB-CEC adapter and other CEC capable hardware, like the Raspberry Pi.
 
-A list of frequently asked questions can be found on [libCEC's FAQ page] (http://libcec.pulse-eight.com/faq).
+A list of FAQ (Frequently Asked Questions) can be found on [libCEC's FAQ page] (http://libcec.pulse-eight.com/faq).
 
 .Net client applications, previously part of this repository, have been moved to [this repository](https://github.com/Pulse-Eight/cec-dotnet).
 
@@ -21,6 +21,7 @@ See [docs/README.windows.md](docs/README.windows.md).
 # Supported hardware
 * [Pulse-Eight USB-CEC Adapter](https://www.pulse-eight.com/p/104/usb-hdmi-cec-adapter)
 * [Pulse-Eight Intel NUC CEC Adapter](https://www.pulse-eight.com/p/154/intel-nuc-hdmi-cec-adapter)
+* [Pulse-Eight CEC Adapter for Skull Canyon and Hades Canyon NUC systems](https://www.pulse-eight.com/p/207/skull-canyon-nuc-cec-adapter)
 * [Raspberry Pi](https://www.raspberrypi.org/)
 * Some Exynos SoCs
 * NXP TDA995x


### PR DESCRIPTION
Update README.md with link to Skull Canyon and Hades Canyon NUC CEC adapter.

Note! Pulse-Eight has two links for it but they appear to be for the same adapter:
* https://www.pulse-eight.com/p/207/skull-canyon-nuc-cec-adapter
* https://www.pulse-eight.com/p/208/hades-canyon-nuc-cec-adapter