### PR TITLE
Fix Hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # About
 This library provides support for Pulse-Eight's USB-CEC adapter and other CEC capable hardware, like the Raspberry Pi.
 
-A list of frequently asked questions can be found on [libCEC's FAQ page] (http://libcec.pulse-eight.com/faq).
+A list of frequently asked questions can be found on [libCEC's FAQ page](http://libcec.pulse-eight.com/faq).
 
 .Net client applications, previously part of this repository, have been moved to [this repository](https://github.com/Pulse-Eight/cec-dotnet).
 

--- a/docs/README.developers.md
+++ b/docs/README.developers.md
@@ -21,4 +21,4 @@ We provide a C, C++, Python and .NET CLR interface to the adapter.
 # Developers Agreement
 
 If you wish to contribute to this project, you must first sign our contributors agreement.
-Please see [the contributors agreement] (http://www.pulse-eight.com/contributors) for more information.
+Please see [the contributors agreement](http://www.pulse-eight.com/contributors) for more information.

--- a/docs/README.linux.md
+++ b/docs/README.linux.md
@@ -2,12 +2,12 @@
 
 ### Prerequisites
 libCEC needs the following dependencies in order to work correctly:
-* [p8-platform] (https://github.com/Pulse-Eight/platform) 2.0 or later
+* [p8-platform](https://github.com/Pulse-Eight/platform) 2.0 or later
 * udev v151 or later
 * cdc-acm support compiled into the kernel or available as module
 
 To compile libCEC on Linux, you'll need the following dependencies:
-* [cmake 2.6 or better] (http://www.cmake.org/)
+* [cmake 2.6 or better](http://www.cmake.org/)
 * a supported C++ 11 compiler
 
 The following dependencies are recommended. Without them, the adapter can not

--- a/docs/README.osx.md
+++ b/docs/README.osx.md
@@ -2,15 +2,15 @@
 
 ### MacPorts
 
-libCEC is available through [MacPorts] (https://www.macports.org/) and has been tested on OS X 10.9 through 10.12
+libCEC is available through [MacPorts](https://www.macports.org/) and has been tested on OS X 10.9 through 10.12
 
 ### Prerequisites
 To compile libCEC on OS X, you'll need the following dependencies:
-* [p8-platform] (https://github.com/Pulse-Eight/platform) 2.0 or later
-* [cmake 2.6 or better] (http://www.cmake.org/)
+* [p8-platform](https://github.com/Pulse-Eight/platform) 2.0 or later
+* [cmake 2.6 or better](http://www.cmake.org/)
 * a supported C++ 11 compiler. Support for C++11 was added in OS X 10.9
 * xcode 3.2.6 or later
-* optional: [Python 3.4 or later] (https://www.python.org/) and [Swig] (http://www.swig.org/) to generate Python bindings
+* optional: [Python 3.4 or later](https://www.python.org/) and [Swig](http://www.swig.org/) to generate Python bindings
 * optional: libX11 and xrandr to read the sink's EDID, used to determine the PC's HDMI physical address
 
 ### Compilation

--- a/docs/README.windows.md
+++ b/docs/README.windows.md
@@ -13,12 +13,12 @@ Example implementations can be found on [Github](https://github.com/Pulse-Eight/
 
 ### Prerequisites
 To compile libCEC on Windows, you'll need the following dependencies:
-* [p8-platform] (https://github.com/Pulse-Eight/platform) 2.0 or later
-* [cmake 2.6 or better] (http://www.cmake.org/)
-* [Visual Studio 2008 (v90) Professional] (https://www.visualstudio.com/)
-* [Visual Studio 2010 (v110) (for x64 builds: Professional)] (https://www.visualstudio.com/)
-* [Visual Studio 2013 (v120) or 2015 (v140)] (https://www.visualstudio.com/)
-* To create an installer, you'll need [Nullsoft's NSIS] (http://nsis.sourceforge.net/)
+* [p8-platform](https://github.com/Pulse-Eight/platform) 2.0 or later
+* [cmake 2.6 or better](http://www.cmake.org/)
+* [Visual Studio 2008 (v90) Professional](https://www.visualstudio.com/)
+* [Visual Studio 2010 (v110) (for x64 builds: Professional)](https://www.visualstudio.com/)
+* [Visual Studio 2013 (v120) or 2015 (v140)](https://www.visualstudio.com/)
+* To create an installer, you'll need [Nullsoft's NSIS](http://nsis.sourceforge.net/)
 
 Visual Studio version must be installed in ascending order, and each version of Visual Studio must be started at least once before the next version is installed.
 


### PR DESCRIPTION
some readme hyperlinks had a extra space between them that made them show up like this [google] (google.com) instead of like this [google](google.com)