### PR TITLE
fixed: fix build if hostname does not support '-f' argument

### DIFF
--- a/src/libcec/cmake/SetBuildInfo.cmake
+++ b/src/libcec/cmake/SetBuildInfo.cmake
@@ -45,7 +45,10 @@ else()
   # add host on which this was built to compile info
   find_program(HAVE_HOSTNAME_BIN hostname /bin /usr/bin /usr/local/bin)
   if(HAVE_HOSTNAME_BIN)
-    exec_program(hostname ARGS -f OUTPUT_VARIABLE BUILD_HOST)
+    exec_program(hostname ARGS -f OUTPUT_VARIABLE BUILD_HOST RETURN_VALUE RETURN_HOST)
+    if (RETURN_HOST)
+      exec_program(hostname OUTPUT_VARIABLE BUILD_HOST)
+    endif()
     set(LIB_INFO "${LIB_INFO}@${BUILD_HOST}")
   endif()
 


### PR DESCRIPTION
Part of the build information compiled into the library is the host on
which it was built. This information is generated by executing the
command `hostname -f`, but the '-f' argument may not be available on all
platforms (e.g. coreutils v8.30 does not have it). As a result, the
command will spit an error message that spans multiple lines, break the
format of the define in "src/libcec/env.h" and as a result the error
will fail due to invalid syntax.

Fix the issue by falling back to just `hostname` if `hostname -f`
returns an error.