### PR TITLE
Adding O_CLOEXEC to prevent child process locking

### DIFF
--- a/src/libcec/platform/posix/serialport.cpp
+++ b/src/libcec/platform/posix/serialport.cpp
@@ -131,7 +131,7 @@ bool CSerialSocket::Open(uint64_t iTimeoutMs /* = 0 */)
     return false;
   }
 
-  m_socket = open(m_strName.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
+  m_socket = open(m_strName.c_str(), O_RDWR | O_NOCTTY | O_NDELAY | O_CLOEXEC);
 
   if (m_socket == INVALID_SERIAL_SOCKET_VALUE)
   {


### PR DESCRIPTION
The serial port should be closed if a child process successfully invokes execve, as failure to do so could result in a child process holding an exclusive lock to the serial port.

See #477 for details.