### PR TITLE
Use cmake TIMESTAMP function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(libcec)
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8.11)
 
 set(LIBCEC_VERSION_MAJOR 4)
 set(LIBCEC_VERSION_MINOR 0)

--- a/src/libcec/cmake/SetBuildInfo.cmake
+++ b/src/libcec/cmake/SetBuildInfo.cmake
@@ -24,13 +24,8 @@ else()
   endif()
 
   # add compilation date to compile info
-  find_program(HAVE_DATE_BIN date /bin /usr/bin /usr/local/bin)
-  if(HAVE_DATE_BIN)
-    exec_program(date ARGS -u OUTPUT_VARIABLE BUILD_DATE)
-    set(LIB_INFO "${LIB_INFO} compiled on ${BUILD_DATE}")
-  else()
-    set(LIB_INFO "${LIB_INFO} compiled on (unknown date)")
-  endif()
+  STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d %H:%M:%S" UTC)
+  set(LIB_INFO "${LIB_INFO} compiled on ${BUILD_DATE}")
 
   # add user who built this to compile info
   find_program(HAVE_WHOAMI_BIN whoami /bin /usr/bin /usr/local/bin)


### PR DESCRIPTION
Use cmake `TIMESTAMP` function
to be more portable
and to allow for reproducible builds.

See https://reproducible-builds.org/ for why this matters.

Also consistently use ISO 8601 date format to be understood everywhere.

Fixes #485