### PR TITLE
IsActiveDeviceType: poll only matching device type

### DIFF
--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -1459,9 +1459,17 @@ bool CCECClient::IsActiveDeviceType(const cec_device_type type)
 {
   CECDEVICEVEC activeDevices;
   if (m_processor)
-    m_processor->GetDevices()->GetActive(activeDevices);
-  CCECDeviceMap::FilterType(type, activeDevices);
-  return !activeDevices.empty();
+    m_processor->GetDevices()->GetByType(type, activeDevices);
+
+  for (CECDEVICEVEC::iterator it = activeDevices.begin(); it != activeDevices.end(); it++)
+  {
+    cec_bus_device_status status = (*it)->GetStatus();
+    if (status == CEC_DEVICE_STATUS_HANDLED_BY_LIBCEC ||
+        status == CEC_DEVICE_STATUS_PRESENT)
+      return true;
+  }
+
+  return false;
 }
 
 cec_logical_address CCECClient::GetActiveSource(void)


### PR DESCRIPTION
There is a delay of 10-30 seconds until key press transfer get functional when starting Kodi with libCEC. The reason is the function `IsActiveDeviceType` because it poll all nodes on the CEC bus. This commit will filter the devices by given type before polling to minimize the delay.

Be lenient with me, I am not so familiar with the libCEC source and I don't have the hardware to test it.
So if this will not work please help to find another way to fix this annoying startup delay.