### PR TITLE
USBCECAdapterDetection: Only scan tty

### DIFF
--- a/src/libcec/adapter/Pulse-Eight/USBCECAdapterDetection.cpp
+++ b/src/libcec/adapter/Pulse-Eight/USBCECAdapterDetection.cpp
@@ -356,6 +356,8 @@ uint8_t CUSBCECAdapterDetection::FindAdaptersUdev(cec_adapter_descriptor *device
   struct udev_list_entry *devices, *dev_list_entry;
   struct udev_device *dev, *pdev;
   enumerate = udev_enumerate_new(udev);
+
+  udev_enumerate_add_match_subsystem(enumerate, "tty");
   udev_enumerate_scan_devices(enumerate);
   devices = udev_enumerate_get_list_entry(enumerate);
   udev_list_entry_foreach(dev_list_entry, devices)


### PR DESCRIPTION
While debugging high CPU load coming from PeripUSBCEC thread I figured that the library call: DetectAdapters hoggs the CPU for up to 200 ms per Call. Looking into it I spotted that the usb udev enumeration and scanning happens on every device in /sys

Therefore: Limit device comparison for the tty subsystem only. This reduces comparisons by factor 4. 100 tty-devices vs. 400 devices in sum. It's a pitty that we need to start with the leafs and then query over the parent.

Runtime tested on LibreELEC.

This is a tested update of https://github.com/Pulse-Eight/libcec/pull/494