### PR TITLE
Linux Adapter: support change in logical address

### DIFF
--- a/src/libcec/adapter/Linux/LinuxCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/Linux/LinuxCECAdapterCommunication.cpp
@@ -383,9 +383,16 @@ void *CLinuxCECAdapterCommunication::Process(void)
         LIB_CEC->AddLog(CEC_LOG_ERROR, "CLinuxCECAdapterCommunication::Process - ioctl CEC_DQEVENT failed - errno=%d", errno);
       else if (ev.event == CEC_EVENT_STATE_CHANGE)
       {
-        LIB_CEC->AddLog(CEC_LOG_DEBUG, "CLinuxCECAdapterCommunication::Process - CEC_DQEVENT - CEC_EVENT_STATE_CHANGE - log_addr_mask=%04x phys_addr=%04x", ev.state_change.log_addr_mask, ev.state_change.phys_addr);
+        LIB_CEC->AddLog(CEC_LOG_DEBUG, "CLinuxCECAdapterCommunication::Process - CEC_DQEVENT - CEC_EVENT_STATE_CHANGE - log_addr_mask=%04x phys_addr=%04x", 
+			ev.state_change.log_addr_mask, ev.state_change.phys_addr);
 
-        // TODO: handle ev.state_change.log_addr_mask change
+        uint32_t mask = 1;
+        for(unsigned int i = 0; i < sizeof(ev.state_change.log_addr_mask)*8; i++)
+        {
+          mask = 1 << i;
+          if(ev.state_change.log_addr_mask & mask)
+             m_callback->HandleLogicalAddressLost((CEC::cec_logical_address)i);
+        }
 
         phys_addr = ev.state_change.phys_addr;
         phys_addr_changed = true;


### PR DESCRIPTION
when multiple devices of the same type (e.g. recoder) are connected to a TV the second
device needs a different logical address. Without that change each
device gets the same logical address in the libcec library, but Linux
kernel assigns a different logical address. This patch de-allocats the
initial logical address being used and re-syncs to the logical address
being used by the kernel