### PR TITLE
Example systemd units for common use cases

### DIFF
--- a/systemd/cec-active-source.service
+++ b/systemd/cec-active-source.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Set this device to the CEC Active Source
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/echo 'on 0' | /usr/bin/cec-client -s
+ExecStart=/bin/echo 'as' | /usr/bin/cec-client -s
+

--- a/systemd/cec-active-source.timer
+++ b/systemd/cec-active-source.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Trigger cec-active-source at boot
+
+[Timer]
+OnBootSec=1
+OnStartupSec=1
+
+[Install]
+WantedBy=timers.target

--- a/systemd/cec-poweroff-tv.service
+++ b/systemd/cec-poweroff-tv.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Use CEC to power off TV
+
+[Service]
+Type=oneshot
+ExecStart=/bin/echo 'standby 0' | /usr/bin/cec-client -s
+ExecStop=/bin/echo 'standby 0' | /usr/bin/cec-client -s
+
+[Install]
+WantedBy=poweroff.target


### PR DESCRIPTION
These sample units cover basic usage on systemd for a number of common use cases for folks not using Kodi.