### PR TITLE
Allows clean upgrades of debian libcec-dev.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,8 @@ Architecture: any
 Section: libdevel
 Depends: libcec4 (= ${binary:Version}),
          ${misc:Depends}
+Replaces: libcec-dev
+Provides: libcec-dev
 Description: libCEC communication Library (development files)
  This library provides support for the Pulse-Eight USB-CEC adapter.
  .


### PR DESCRIPTION
The only other change needed for clean upgrades from libcec4 is to do this in the destination library folder.

```ln -s libcec.so libcec.so.4```