### PR TITLE
ActivateSource: Fix nullptr dereference

### DIFF
--- a/src/libcec/implementations/SLCommandHandler.cpp
+++ b/src/libcec/implementations/SLCommandHandler.cpp
@@ -385,20 +385,21 @@ bool CSLCommandHandler::ActivateSource(bool bTransmitDelayedCommandsOnly /* = fa
     }
 
     CCECPlaybackDevice *device = m_busDevice->AsPlaybackDevice();
-    if (device)
+    bool bActiveSourceFailed(true);
+    if (device) {
       device->SetDeckStatus(!device->IsActiveSource() ? CEC_DECK_INFO_OTHER_STATUS : CEC_DECK_INFO_OTHER_STATUS_LG);
 
-    // power on the TV
-    CCECBusDevice* tv = m_processor->GetDevice(CECDEVICE_TV);
-    bool bTvPresent = (tv && tv->GetStatus() == CEC_DEVICE_STATUS_PRESENT);
-    bool bActiveSourceFailed(false);
-    if (bTvPresent)
-    {
-      bActiveSourceFailed = !device->TransmitImageViewOn();
-    }
-    else
-    {
-      LIB_CEC->AddLog(CEC_LOG_DEBUG, "TV not present, not sending 'image view on'");
+      // power on the TV
+      CCECBusDevice* tv = m_processor->GetDevice(CECDEVICE_TV);
+      bool bTvPresent = (tv && tv->GetStatus() == CEC_DEVICE_STATUS_PRESENT);
+      if (bTvPresent)
+      {
+        bActiveSourceFailed = !device->TransmitImageViewOn();
+      }
+      else
+      {
+        LIB_CEC->AddLog(CEC_LOG_DEBUG, "TV not present, not sending 'image view on'");
+      }
     }
 
     // check if we're allowed to switch sources

--- a/src/libcec/implementations/SLCommandHandler.cpp
+++ b/src/libcec/implementations/SLCommandHandler.cpp
@@ -385,7 +385,7 @@ bool CSLCommandHandler::ActivateSource(bool bTransmitDelayedCommandsOnly /* = fa
     }
 
     CCECPlaybackDevice *device = m_busDevice->AsPlaybackDevice();
-    bool bActiveSourceFailed(true);
+    bool bActiveSourceFailed(false);
     if (device) {
       device->SetDeckStatus(!device->IsActiveSource() ? CEC_DECK_INFO_OTHER_STATUS : CEC_DECK_INFO_OTHER_STATUS_LG);
 


### PR DESCRIPTION
the initial nullptr check for device does not cover the condition where bTvPresent is found to be true and device is dereferenced again. I've moved the bTvPresent into the device nullptr check to cover this case.