### PR TITLE
Ease copy-paste by invoking apt noninteractively

### DIFF
--- a/docs/README.raspberrypi.md
+++ b/docs/README.raspberrypi.md
@@ -21,7 +21,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/CrossCompile.cmake \
 To compile libCEC on a new Raspbian installation, follow these instructions:
 ```
 sudo apt-get update
-sudo apt-get install cmake libudev-dev libxrandr-dev python3-dev swig git
+sudo apt-get -y install cmake libudev-dev libxrandr-dev python3-dev swig git
 cd
 git clone https://github.com/Pulse-Eight/platform.git
 mkdir platform/build


### PR DESCRIPTION
Adding -y skips the confirmation which is a bit of a bother when you're copy-pasting.