### PR TITLE
Update and robustify

### DIFF
--- a/docs/README.debian.md
+++ b/docs/README.debian.md
@@ -1,7 +1,7 @@
 ### Debian
 Use the following commands to create a Debian package:
 ```
-source /etc/lsb-release
-sed "s/#DIST#/${DISTRIB_CODENAME}/g" debian/changelog.in > debian/changelog
-dpkg-buildpackage
+sudo apt-get build-dep . # to install build dependencies
+sed "s/#DIST#/$(lsb_release -cs)/g" debian/changelog.in > debian/changelog
+dpkg-buildpackage --no-sign # omit this argument if you have a private key to sign with
 ```


### PR DESCRIPTION
1) dpkg-buildpackage will exit if build dependencies are not installed. This added line will install build dependencies for that directory.

2) lsb_release -cs will work on certainly every version of Debian that I have used and /etc/lsb-release was not there on my raspbian

3) --no-sign is required to build packages if you do not have private keys for this purpose (as I did not)

The above commands work to build the package on raspbian 10. :)