### PR TITLE
Add an udev rule making the CEC adapter part of the input group

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,3 +44,7 @@ if(WIN32)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/dotnet/src/CecSharpTester/netfx/Properties/AssemblyInfo.cs.in
                  ${CMAKE_CURRENT_SOURCE_DIR}/src/dotnet/src/CecSharpTester/netfx/Properties/AssemblyInfo.cs)
 endif()
+
+if(UNIX AND NOT APPLE)
+	install(FILES udev/90-hdmi-cec.rules DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d)
+endif()

--- a/udev/90-hdmi-cec.rules
+++ b/udev/90-hdmi-cec.rules
@@ -1,0 +1,2 @@
+# Pulse-Eight CEC adapter
+KERNEL=="ttyACM[0-9]*", SUBSYSTEM=="tty", ATTRS{idVendor}=="2548", ATTRS{idProduct}=="1002", GROUP="input"


### PR DESCRIPTION
Without this, the HDMI CEC USB adapter appears as /dev/ttyACM0 owned by
the dialout group with mode 660. This means that any user that wants to
use this device needs to be part of the dialout group. This actually has
security concerns as all serial devices are owned by that group as well
and it would give the user too much control of them, meaning any rogue
process can cause harm without needing root access.

Since the CEC adapter is actually used as an input device, this udev
rule makes the device be part of the input group instead. This makes
sense as it _is_ an input device and any rogue process shouldn't be able
to do to much harm with that group. On most distributions the standard
user is part of that group by default anyway