### PR TITLE
cecloader.h: fix null return

### DIFF
--- a/include/cecloader.h
+++ b/include/cecloader.h
@@ -172,7 +172,7 @@ bool LibCecBootloader(const char *strLib = NULL)
     if (!g_libCEC)
     {
       std::cout << dlerror() << std::endl;
-      return NULL;
+      return false;
     }
   }
 
@@ -181,7 +181,7 @@ bool LibCecBootloader(const char *strLib = NULL)
   if (!LibCecBootloader)
   {
     std::cout << "cannot find CECStartBootloader" << std::endl;
-    return NULL;
+    return false;
   }
 
   bool bReturn = LibCecBootloader();


### PR DESCRIPTION
returning NULL is invalid for a return type of bool when NULL is defined  
as `nullptr` instead of 0L