### PR TITLE
editorconfig: add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+trim_trailing_whitespace = true
+
+[*.{c,h,cpp}]
+indent_style = space
+tab_width = 2
+max_line_length = 120


### PR DESCRIPTION
Add an initial editorconfig file to allow consistent space / tab
configuration across text editors and projects.