### PR TITLE
Add default HDMI port to fall back to when resetting

### DIFF
--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -1482,6 +1482,7 @@ struct libcec_configuration
   uint16_t              iPhysicalAddress;     /*!< the physical address of the CEC adapter */
   cec_logical_address   baseDevice;           /*!< the logical address of the device to which the adapter is connected. only used when iPhysicalAddress = 0 or when the adapter doesn't support autodetection */
   uint8_t               iHDMIPort;            /*!< the HDMI port to which the adapter is connected. only used when iPhysicalAddress = 0 or when the adapter doesn't support autodetection */
+  uint8_t               iDefaultHDMIPort;     /*!< the default HDMI port to fall back to when resetting. */
   uint32_t              tvVendor;             /*!< override the vendor ID of the TV. leave this untouched to autodetect */
   cec_logical_addresses wakeDevices;          /*!< list of devices to wake when initialising libCEC or when calling PowerOnDevices() without any parameter. */
   cec_logical_addresses powerOffDevices;      /*!< list of devices to power off when calling StandbyDevices() without any parameter. */
@@ -1526,6 +1527,7 @@ struct libcec_configuration
                  iPhysicalAddress          == other.iPhysicalAddress &&
                  baseDevice                == other.baseDevice &&
                  iHDMIPort                 == other.iHDMIPort &&
+                 iDefaultHDMIPort          == other.iDefaultHDMIPort &&
                  tvVendor                  == other.tvVendor &&
                  wakeDevices               == other.wakeDevices &&
                  powerOffDevices           == other.powerOffDevices &&
@@ -1565,6 +1567,7 @@ struct libcec_configuration
     iPhysicalAddress =                CEC_PHYSICAL_ADDRESS_TV;
     baseDevice = (cec_logical_address)CEC_DEFAULT_BASE_DEVICE;
     iHDMIPort =                       CEC_DEFAULT_HDMI_PORT;
+    iDefaultHDMIPort =                CEC_DEFAULT_HDMI_PORT;
     tvVendor =              (uint32_t)CEC_VENDOR_UNKNOWN;
     clientVersion =                   LIBCEC_VERSION_CURRENT;
     serverVersion =                   LIBCEC_VERSION_CURRENT;

--- a/src/cec-client/cec-client.cpp
+++ b/src/cec-client/cec-client.cpp
@@ -299,6 +299,7 @@ void ShowHelpCommandLine(const char* strExec)
       "  -l --list-devices           List all devices on this system" << std::endl <<
       "  -t --type {p|r|t|a}         The device type to use. More than one is possible." << std::endl <<
       "  -p --port {int}             The HDMI port to use as active source." << std::endl <<
+      "  -dp --default-port {int}    The default HDMI port to fall back to when resetting." << std::endl <<
       "  -b --base {int}             The logical address of the device to which this " << std::endl <<
       "                              adapter is connected." << std::endl <<
       "  -f --log-file {file}        Writes all libCEC log message to a file" << std::endl <<
@@ -1164,6 +1165,22 @@ bool ProcessCommandLineArguments(int argc, char *argv[])
               hdmiport = 15;
           g_config.iHDMIPort = hdmiport;
           std::cout << "using HDMI port '" << (int)g_config.iHDMIPort << "'" << std::endl;
+          ++iArgPtr;
+        }
+        ++iArgPtr;
+      }
+      else if (!strcmp(argv[iArgPtr], "-dp") ||
+               !strcmp(argv[iArgPtr], "--default-port"))
+      {
+        if (argc >= iArgPtr + 2)
+        {
+          uint8_t hdmiport = (int8_t)atoi(argv[iArgPtr + 1]);
+          if (hdmiport < 1)
+              hdmiport = 1;
+          if (hdmiport > 15)
+              hdmiport = 15;
+          g_config.iDefaultHDMIPort = hdmiport;
+          std::cout << "using default HDMI port '" << (int)g_config.iDefaultHDMIPort << "'" << std::endl;
           ++iArgPtr;
         }
         ++iArgPtr;

--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -261,6 +261,22 @@ static int cec_process_command_line_arguments(int argc, char *argv[])
         }
         ++iArgPtr;
       }
+      else if (!strcmp(argv[iArgPtr], "-dp") ||
+               !strcmp(argv[iArgPtr], "--default-port"))
+      {
+        if (argc >= iArgPtr + 2)
+        {
+          uint8_t hdmiport = (int8_t)atoi(argv[iArgPtr + 1]);
+          if (hdmiport < 1)
+              hdmiport = 1;
+          if (hdmiport > 15)
+              hdmiport = 15;
+          g_config.iDefaultHDMIPort = hdmiport;
+          printf("using default HDMI port '%d'\n", (int)g_config.iDefaultHDMIPort);
+          ++iArgPtr;
+        }
+        ++iArgPtr;
+      }
       else if (!strcmp(argv[iArgPtr], "-r") ||
                !strcmp(argv[iArgPtr], "--rom"))
       {

--- a/src/dotnetlib/CecSharpTypes.h
+++ b/src/dotnetlib/CecSharpTypes.h
@@ -1621,6 +1621,7 @@ namespace CecSharp
       PhysicalAddress     = CEC_DEFAULT_PHYSICAL_ADDRESS;
       BaseDevice          = (CecLogicalAddress)CEC_DEFAULT_BASE_DEVICE;
       HDMIPort            = CEC_DEFAULT_HDMI_PORT;
+      DefaultHDMIPort     = CEC_DEFAULT_HDMI_PORT;
       ClientVersion       = _LIBCEC_VERSION_CURRENT;
       ServerVersion       = 0;
       TvVendor            = CecVendorId::Unknown;
@@ -1688,6 +1689,7 @@ namespace CecSharp
       PhysicalAddress      = config.iPhysicalAddress;
       BaseDevice           = (CecLogicalAddress)config.baseDevice;
       HDMIPort             = config.iHDMIPort;
+      DefaultHDMIPort      = config.iDefaultHDMIPort;
       ClientVersion        = config.clientVersion;
       ServerVersion        = config.serverVersion;
       TvVendor             = (CecVendorId)config.tvVendor;
@@ -1727,6 +1729,7 @@ namespace CecSharp
       PhysicalAddress      = config->PhysicalAddress;
       BaseDevice           = config->BaseDevice;
       HDMIPort             = config->HDMIPort;
+      DefaultHDMIPort      = config->DefaultHDMIPort;
       ClientVersion        = config->ClientVersion;
       ServerVersion        = config->ServerVersion;
       TvVendor             = config->TvVendor;
@@ -1779,6 +1782,11 @@ namespace CecSharp
     /// The HDMI port to which the adapter is connected. Only used when iPhysicalAddress = 0 or when the adapter doesn't support autodetection
     /// </summary>
     property uint8_t              HDMIPort;
+
+    /// <summary>
+    /// The default HDMI port to fall back to when resetting.
+    /// </summary>
+    property uint8_t              DefaultHDMIPort;
 
     /// <summary>
     /// The client API version to use

--- a/src/dotnetlib/LibCecSharp.cpp
+++ b/src/dotnetlib/LibCecSharp.cpp
@@ -894,6 +894,7 @@ namespace CecSharp
       config.iPhysicalAddress      = netConfig->PhysicalAddress;
       config.baseDevice            = (cec_logical_address)netConfig->BaseDevice;
       config.iHDMIPort             = netConfig->HDMIPort;
+      config.iDefaultHDMIPort      = netConfig->DefaultHDMIPort;
       config.clientVersion         = netConfig->ClientVersion;
       config.bGetSettingsFromROM   = netConfig->GetSettingsFromROM ? 1 : 0;
       config.bActivateSource       = netConfig->ActivateSource ? 1 : 0;

--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -225,7 +225,7 @@ bool CCECClient::SetHDMIPort(const cec_logical_address iBaseDevice, const uint8_
 void CCECClient::ResetPhysicalAddress(void)
 {
   LIB_CEC->AddLog(CEC_LOG_DEBUG, "resetting HDMI port and base device to defaults");
-  SetHDMIPort(CECDEVICE_TV, CEC_DEFAULT_HDMI_PORT);
+  SetHDMIPort(CECDEVICE_TV, m_configuration.iDefaultHDMIPort);
 }
 
 bool CCECClient::SetPhysicalAddress(const libcec_configuration &configuration)
@@ -855,6 +855,7 @@ bool CCECClient::GetCurrentConfiguration(libcec_configuration &configuration)
   configuration.iPhysicalAddress          = m_configuration.iPhysicalAddress;
   configuration.baseDevice                = m_configuration.baseDevice;
   configuration.iHDMIPort                 = m_configuration.iHDMIPort;
+  configuration.iDefaultHDMIPort          = m_configuration.iDefaultHDMIPort;
   configuration.clientVersion             = m_configuration.clientVersion;
   configuration.serverVersion             = LIBCEC_VERSION_CURRENT;
   configuration.tvVendor                  = m_configuration.tvVendor;
@@ -906,6 +907,7 @@ bool CCECClient::SetConfiguration(const libcec_configuration &configuration)
     CLockObject lock(m_mutex);
     m_configuration.bActivateSource            = configuration.bActivateSource;
     m_configuration.bGetSettingsFromROM        = configuration.bGetSettingsFromROM;
+    m_configuration.iDefaultHDMIPort           = configuration.iDefaultHDMIPort;
     m_configuration.wakeDevices                = configuration.wakeDevices;
     m_configuration.powerOffDevices            = configuration.powerOffDevices;
     memcpy(m_configuration.strDeviceLanguage,   configuration.strDeviceLanguage, 3);


### PR DESCRIPTION
With a Pulse-Eight USB CEC adapter connected to HDMI2 (and nothing plugged into HDMI1) on a Samsung HG32NJ690FF or Samsung HG32NF693GF (haven't tested other Samsung models) with the TV set to always start up with TV as the source, if you power off the TV, then send the 'p 0 2' command in cec-client.exe, then send the 'as' command in cec-client.exe, you will see the TV power on to TV briefly, then switch to HDMI2, then about 10 seconds later, the TV switches to HDMI1 due to a physical address conflict that causes libcec to switch the TV to HDMI1 because it is resetting to its default HDMI port of HDMI1. We want the TV to show us HDMI2 when we send a command to libcec to turn on the TV and show us HDMI2.