### PR TITLE
Mark all devices as inactive source when previous active source is unknown

### DIFF
--- a/src/libcec/devices/CECBusDevice.cpp
+++ b/src/libcec/devices/CECBusDevice.cpp
@@ -1272,6 +1272,14 @@ void CCECBusDevice::SetStreamPath(uint16_t iNewAddress, uint16_t iOldAddress /* 
     device = m_processor->GetDeviceByPhysicalAddress(iOldAddress);
     if (device)
       device->MarkAsInactiveSource();
+    else
+    {
+      // mark all devices as inactive sources
+      CECDEVICEVEC devices;
+      m_processor->GetDevices()->Get(devices);
+      for (CECDEVICEVEC::iterator it = devices.begin(); it != devices.end(); it++)
+        (*it)->MarkAsInactiveSource();
+    }
   }
 }
 


### PR DESCRIPTION
This PR makes sure all the devices known by libcec are marked as inactive when the active device changes and libcec does not manage the newly active device.

When switching to a new active device, the `CCECBusDevice::SetStreamPath()` method can accept a second argument which is supposed to be the address of the previously active device. However, this argument seems to never be passed in libcec, so it is always set to the default value `CEC_INVALID_PHYSICAL_ADDRESS`. In this case, the previously active device is not found, and then, the previously active device is still active from libcec point of view if the newly active device is not managed by libcec.
This is an issue, especially when the TV requests the active source device afterwards, because libcec will send the address of the active device it believes is active, while this device is not active anymore.

An example issue can be seen in the following log, where the active device is changed from 2000 (kodi) to 1000 (another device), then the TV if powered off and finally on. When the TV is powered on, the input source changes to 2000, because libcec answers to the active source request while it should not.
<details>
<summary>Kodi CEC debug log</summary>

```
-- Changing input source on TV
2022-09-08 01:03:37.918 T:2600083648   DEBUG: CecLogMessage - >> 0f:80:20:00:10:00
2022-09-08 01:03:37.918 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Broadcast (F): routing change (80)
2022-09-08 01:03:38.258 T:2600083648   DEBUG: CecLogMessage - >> 0f:86:10:00
2022-09-08 01:03:38.258 T:2600083648   DEBUG: CecLogMessage - >> TV (0) sets stream path to physical address 1000
2022-09-08 01:03:38.258 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Broadcast (F): set stream path (86)
-- Powering TV off
2022-09-08 01:03:51.141 T:2600083648   DEBUG: CecLogMessage - >> 0f:36
2022-09-08 01:03:51.141 T:2600083648   DEBUG: CecLogMessage - TV (0): power status changed from 'on' to 'standby'
2022-09-08 01:03:51.141 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Broadcast (F): standby (36)
-- Powering TV on
2022-09-08 01:03:58.389 T:2600083648   DEBUG: CecLogMessage - >> 0f:85
2022-09-08 01:03:58.389 T:2600083648   DEBUG: CecLogMessage - >> 0 requests active source
2022-09-08 01:03:58.390 T:2600083648   DEBUG: CecLogMessage - TV (0): power status changed from 'standby' to 'on'
2022-09-08 01:03:58.390 T:2600083648   DEBUG: CecLogMessage - << Recorder 1 (1) -> broadcast (F): active source (2000)
2022-09-08 01:03:58.390 T:2600083648   DEBUG: CecLogMessage - << 1f:82:20:00
2022-09-08 01:03:58.390 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Broadcast (F): request active source (85)
2022-09-08 01:03:59.147 T:2600083648   DEBUG: CecLogMessage - >> 0f:80:10:00:20:00
2022-09-08 01:03:59.147 T:2600083648   DEBUG: CecLogMessage - Recorder 1 (1) was already marked as active source
2022-09-08 01:03:59.147 T:2600083648   DEBUG: CecLogMessage - >> source activated: Recorder 1 (1)
2022-09-08 01:03:59.147 T:2600083648   DEBUG: CecLogMessage - sending active source message for 'Recorder 1'
2022-09-08 01:03:59.148 T:2600083648   DEBUG: CecLogMessage - << powering on 'TV' (0)
2022-09-08 01:03:59.148 T:2600083648   DEBUG: CecLogMessage - << 10:04
2022-09-08 01:03:59.148 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Broadcast (F): routing change (80)
2022-09-08 01:03:59.237 T:2600083648   DEBUG: CecLogMessage - << Recorder 1 (1) -> broadcast (F): active source (2000)
2022-09-08 01:03:59.238 T:2600083648   DEBUG: CecLogMessage - << 1f:82:20:00
2022-09-08 01:03:59.358 T:2600083648   DEBUG: CecLogMessage - << Recorder 1 (1) -> TV (0): menu state 'activated'
2022-09-08 01:03:59.358 T:2600083648   DEBUG: CecLogMessage - 'menu status' is marked as unsupported feature for device 'TV'
2022-09-08 01:03:59.444 T:2600083648   DEBUG: CecLogMessage - >> 0f:86:20:00
2022-09-08 01:03:59.445 T:2600083648   DEBUG: CecLogMessage - >> TV (0) sets stream path to physical address 2000
2022-09-08 01:03:59.445 T:2600083648   DEBUG: CecLogMessage - Recorder 1 (1) was already marked as active source
2022-09-08 01:03:59.445 T:2600083648   DEBUG: CecLogMessage - >> source activated: Recorder 1 (1)
2022-09-08 01:03:59.445 T:2600083648   DEBUG: CecLogMessage - << Recorder 1 (1) -> broadcast (F): active source (2000)
2022-09-08 01:03:59.446 T:2600083648   DEBUG: CecLogMessage - << 1f:82:20:00
2022-09-08 01:03:59.446 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Broadcast (F): set stream path (86)
2022-09-08 01:04:00.001 T:2600083648   DEBUG: CecLogMessage - GetPhysicalAddress - physical address = 2000
2022-09-08 01:04:05.129 T:2600083648   DEBUG: CecLogMessage - >> 01:83
2022-09-08 01:04:05.130 T:2600083648   DEBUG: CecLogMessage - << Recorder 1 (1) -> broadcast (F): physical address 2000
2022-09-08 01:04:05.130 T:2600083648   DEBUG: CecLogMessage - << 1f:84:20:00:01
2022-09-08 01:04:05.130 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Recorder 1 (1): give physical address (83)
2022-09-08 01:04:06.565 T:2600083648   DEBUG: CecLogMessage - >> 0f:87:08:00:1f
2022-09-08 01:04:06.565 T:2600083648   DEBUG: CecLogMessage - << Recorder 1 (1) -> Broadcast (F): vendor id Pulse Eight (1582)
2022-09-08 01:04:06.566 T:2600083648   DEBUG: CecLogMessage - << 1f:87:00:15:82
2022-09-08 01:04:06.566 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Broadcast (F): device vendor id (87)
2022-09-08 01:04:06.764 T:2600083648   DEBUG: CecLogMessage - >> 01:8c
2022-09-08 01:04:06.764 T:2600083648   DEBUG: CecLogMessage - << Recorder 1 (1) -> TV (0): vendor id Pulse Eight (1582)
2022-09-08 01:04:06.764 T:2600083648   DEBUG: CecLogMessage - << 1f:87:00:15:82
2022-09-08 01:04:06.764 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Recorder 1 (1): give device vendor id (8C)
2022-09-08 01:04:06.962 T:2600083648   DEBUG: CecLogMessage - >> 01:46
2022-09-08 01:04:06.962 T:2600083648   DEBUG: CecLogMessage - << Recorder 1 (1) -> TV (0): OSD name 'Kodi'
2022-09-08 01:04:06.963 T:2600083648   DEBUG: CecLogMessage - << 10:47:4b:6f:64:69
2022-09-08 01:04:06.963 T:2600083648   DEBUG: CecLogMessage - >> TV (0) -> Recorder 1 (1): give osd name (46)
```
</details>

On a side note, the second argument to `CCECBusDevice::SetStreamPath()` is not part of the related CEC message, so it is unclear why it exists at all. It only seems to exist for the "Routing Change" message, so there is probably a mistake here.