### PR TITLE
Fix use after free in callbacks with results.

### DIFF
--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -1624,6 +1624,7 @@ void* CCECClient::Process(void)
   {
     if (m_callbackCalls.Pop(cb, 500))
     {
+      bool keepResult = cb->m_keepResult;
       try
       {
         switch (cb->m_type)
@@ -1653,7 +1654,7 @@ void* CCECClient::Process(void)
           break;
         }
 
-        if (!cb->m_keepResult)
+        if (!keepResult)
           delete cb;
       } catch (...)
       {

--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -1604,11 +1604,12 @@ void CCECClient::QueueConfigurationChanged(const libcec_configuration& config)
 
 int CCECClient::QueueMenuStateChanged(const cec_menu_state newState)
 {
-  CCallbackWrap *wrapState = new CCallbackWrap(newState, true);
+  CCallbackWrap *wrapState = new CCallbackWrap(newState);
   m_callbackCalls.Push(wrapState);
   int result(wrapState->Result(1000));
 
-  delete wrapState;
+  if (wrapState->m_keepResult)
+    delete wrapState;
   return result;
 }
 
@@ -1645,7 +1646,7 @@ void* CCECClient::Process(void)
           CallbackConfigurationChanged(cb->m_config);
           break;
         case CCallbackWrap::CEC_CB_MENU_STATE:
-          cb->Report(CallbackMenuStateChanged(cb->m_menuState));
+          keepResult = cb->Report(CallbackMenuStateChanged(cb->m_menuState));
           break;
         case CCallbackWrap::CEC_CB_SOURCE_ACTIVATED:
           CallbackSourceActivated(cb->m_bActivated, cb->m_logicalAddress);

--- a/src/libcec/CECClient.h
+++ b/src/libcec/CECClient.h
@@ -107,13 +107,13 @@ namespace CEC
       m_result(0),
       m_bSucceeded(false) {}
 
-    CCallbackWrap(const cec_menu_state newState, const bool keepResult = false) :
+    CCallbackWrap(const cec_menu_state newState) :
       m_type(CEC_CB_MENU_STATE),
       m_alertType(CEC_ALERT_SERVICE_DEVICE),
       m_menuState(newState),
       m_bActivated(false),
       m_logicalAddress(CECDEVICE_UNKNOWN),
-      m_keepResult(keepResult),
+      m_keepResult(true),
       m_result(0),
       m_bSucceeded(false) {}
 
@@ -134,16 +134,18 @@ namespace CEC
       bool bReturn = m_bSucceeded ? true : m_condition.Wait(m_mutex, m_bSucceeded, iTimeout);
       if (bReturn)
         return m_result;
+      m_keepResult = false;
       return 0;
     }
 
-    void Report(int result)
+    bool Report(int result)
     {
       P8PLATFORM::CLockObject lock(m_mutex);
 
       m_result = result;
       m_bSucceeded = true;
       m_condition.Signal();
+      return m_keepResult;
     }
 
     enum callbackWrapType {

--- a/src/libcec/LibCEC.cpp
+++ b/src/libcec/LibCEC.cpp
@@ -408,7 +408,6 @@ void CLibCEC::AddLog(const cec_log_level level, const char *strFormat, ...)
   va_end(argList);
 
   // send the message to all clients
-  CLockObject lock(m_mutex);
   for (std::vector<CECClientPtr>::iterator it = m_clients.begin(); it != m_clients.end(); it++)
     (*it)->AddLog(message);
 }
@@ -416,7 +415,6 @@ void CLibCEC::AddLog(const cec_log_level level, const char *strFormat, ...)
 void CLibCEC::AddCommand(const cec_command &command)
 {
   // send the command to all clients
-  CLockObject lock(m_mutex);
   for (std::vector<CECClientPtr>::iterator it = m_clients.begin(); it != m_clients.end(); it++)
     (*it)->QueueAddCommand(command);
 }
@@ -424,7 +422,6 @@ void CLibCEC::AddCommand(const cec_command &command)
 void CLibCEC::Alert(const libcec_alert type, const libcec_parameter &param)
 {
   // send the alert to all clients
-  CLockObject lock(m_mutex);
   for (std::vector<CECClientPtr>::iterator it = m_clients.begin(); it != m_clients.end(); it++)
     (*it)->Alert(type, param);
 }

--- a/src/libcec/LibCEC.h
+++ b/src/libcec/LibCEC.h
@@ -169,7 +169,6 @@ namespace CEC
 
     protected:
       int64_t                   m_iStartTime;
-      P8PLATFORM::CMutex        m_mutex;
       CECClientPtr              m_client;
       std::vector<CECClientPtr> m_clients;
   };


### PR DESCRIPTION
There is a use-after-free bug in menu state change callback.

in line CECClient.cpp:1656, cb->m_keepResult is check to find out if the callbackWrap needs to be deleted or not.
However in CCECClient::QueueMenuStateChanged, the callback is deleted right after Result().

By the time Report() finishes, the callback is already delted and thus the value if cb->m_keepResult should not be access and can become 0 leading to a double free.
