### PR TITLE
tegra-cec support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ AssemblyInfo.cs
 AssemblyInfo.cpp
 
 *~
+tags
+cscope.*
 
 /support/private
 

--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -887,7 +887,8 @@ typedef enum cec_adapter_type
   ADAPTERTYPE_EXYNOS           = 0x300,
   ADAPTERTYPE_LINUX            = 0x400,
   ADAPTERTYPE_AOCEC            = 0x500,
-  ADAPTERTYPE_IMX              = 0x600
+  ADAPTERTYPE_IMX              = 0x600,
+  ADAPTERTYPE_TEGRA            = 0x700
 } cec_adapter_type;
 
 /** force exporting through swig */

--- a/src/libcec/CECTypeUtils.h
+++ b/src/libcec/CECTypeUtils.h
@@ -774,6 +774,8 @@ namespace CEC
         return "i.MX";
       case ADAPTERTYPE_LINUX:
         return "Linux";
+      case ADAPTERTYPE_TEGRA:
+        return "Tegra";
       default:
         return "unknown";
       }

--- a/src/libcec/adapter/Tegra/AdapterMessageQueue.h
+++ b/src/libcec/adapter/Tegra/AdapterMessageQueue.h
@@ -1,0 +1,134 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "p8-platform/threads/mutex.h"
+
+namespace CEC
+{
+  using namespace P8PLATFORM;
+  
+  class CAdapterMessageQueueEntry
+  {
+  public:
+    CAdapterMessageQueueEntry(const cec_command &command)
+       : m_bWaiting(true), m_retval((uint32_t)-1), m_bSucceeded(false)
+    {
+      m_hash = hashValue(
+    	uint32_t(command.opcode_set ? command.opcode : CEC_OPCODE_NONE),
+        command.initiator, command.destination);
+    }
+    
+    virtual ~CAdapterMessageQueueEntry(void) {}
+
+    /*!
+     * @brief Query result from worker thread
+     */
+    uint32_t Result() const
+    {
+      return m_retval;
+    }
+    
+    /*!
+     * @brief Signal waiting threads
+     */
+    void Broadcast(void)
+    {
+      CLockObject lock(m_mutex);
+      m_condition.Broadcast();
+    }
+
+    /*!
+     * @brief Signal waiting thread(s) when message matches this entry
+     */
+    bool CheckMatch(uint32_t opcode, cec_logical_address initiator, 
+                    cec_logical_address destination, uint32_t response)
+    {
+      uint32_t hash = hashValue(opcode, initiator, destination);
+      
+      if (hash == m_hash)
+      {
+        CLockObject lock(m_mutex);
+
+        m_retval = response;
+        m_bSucceeded = true;
+        m_condition.Signal();
+        return true;
+      }
+      
+      return false;
+    }
+
+    /*!
+     * @brief Wait for a response to this command.
+     * @param iTimeout The timeout to use while waiting.
+     * @return True when a response was received before the timeout passed, false otherwise.
+     */
+    bool Wait(uint32_t iTimeout)
+    {
+      CLockObject lock(m_mutex);
+      
+      bool bReturn = m_bSucceeded ? true : m_condition.Wait(m_mutex, m_bSucceeded, iTimeout);
+      m_bWaiting = false;
+      return bReturn;
+    }
+
+    /*!
+     * @return True while a thread is waiting for a signal or isn't waiting yet, false otherwise.
+     */
+    bool IsWaiting(void)
+    {
+      CLockObject lock(m_mutex);
+      return m_bWaiting;
+    }
+
+    /*!
+     * @return Hash value for given cec_command
+     */
+    static uint32_t hashValue(uint32_t opcode, 
+                              cec_logical_address initiator,  
+                              cec_logical_address destination)
+    {
+      return 1 | ((uint32_t)initiator << 8) | 
+             ((uint32_t)destination << 16) | ((uint32_t)opcode << 16);
+    }
+    
+  private:    
+    bool                           m_bWaiting;     /**< true while a thread is waiting or when it hasn't started waiting yet */
+    P8PLATFORM::CCondition<bool>   m_condition;    /**< the condition to wait on */
+    P8PLATFORM::CMutex             m_mutex;        /**< mutex for changes to this class */
+    uint32_t                  	   m_hash;
+    uint32_t                       m_retval;
+    bool                           m_bSucceeded;
+  };
+ 
+};

--- a/src/libcec/adapter/Tegra/TegraCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/Tegra/TegraCECAdapterCommunication.cpp
@@ -1,0 +1,311 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/CTegraCECAdapterCommunication
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+
+#if defined(HAVE_TEGRA_API)
+#include "TegraCECAdapterCommunication.h"
+#include "TegraCECDev.h"
+
+#include "CECTypeUtils.h"
+#include "LibCEC.h"
+#include "p8-platform/sockets/cdevsocket.h"
+#include "p8-platform/util/StdString.h"
+#include "p8-platform/util/buffer.h"
+
+using namespace std;
+using namespace CEC;
+using namespace P8PLATFORM;
+
+#include "AdapterMessageQueue.h"
+
+#define LIB_CEC m_callback->GetLib()
+
+TegraCECAdapterCommunication::TegraCECAdapterCommunication(IAdapterCommunicationCallback *callback) :
+    IAdapterCommunication(callback),
+    m_bLogicalAddressChanged(false)
+{
+  CLockObject lock(m_mutex);
+  LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Creating Adaptor", __func__);
+  m_iNextMessage = 0;
+  m_logicalAddresses.Clear();
+}
+
+TegraCECAdapterCommunication::~TegraCECAdapterCommunication(void)
+{
+  Close();
+  CLockObject lock(m_mutex);
+  delete m_dev;
+  m_dev = 0;
+}
+
+bool TegraCECAdapterCommunication::IsOpen(void)
+{
+  return devOpen;
+}
+
+bool TegraCECAdapterCommunication::Open(uint32_t iTimeoutMs, bool UNUSED(bSkipChecks), bool bStartListening)
+{
+
+  fd = open(TEGRA_CEC_DEV_PATH, O_RDWR);
+
+  if (fd < 0){
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Failed To Open Tegra CEC Device", __func__);
+    return false;
+  }
+
+  fdAddr = open(TEGRA_ADDR_PATH, O_RDWR);
+
+  if (fdAddr < 0){
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Failed To Open Tegra Logical Address Node", __func__);
+    close(fd);
+    return false;
+  }
+  if (!bStartListening)
+  {
+    Close();
+    return true;
+  }
+
+
+  if (CreateThread()){
+    devOpen = true;
+    return true;
+  }
+
+  return false;
+}
+
+void TegraCECAdapterCommunication::Close(void)
+{
+  StopThread(0);
+  close(fdAddr);
+  close(fd);
+  devOpen = false;
+}
+
+std::string TegraCECAdapterCommunication::GetError(void) const
+{
+  std::string strError(m_strError);
+  return strError;
+}
+
+cec_adapter_message_state TegraCECAdapterCommunication::Write(
+  const cec_command &data, bool &UNUSED(bRetry), uint8_t UNUSED(iLineTimeout), bool UNUSED(bIsReply))
+{
+
+  int size = 0;
+  unsigned char cmdData[TEGRA_CEC_FRAME_MAX_LENGTH];
+  unsigned char addr = (data.initiator << 4) | (data.destination & 0x0f);
+
+  if (data.initiator == data.destination){
+    return ADAPTER_MESSAGE_STATE_SENT_NOT_ACKED;
+  }
+
+  cmdData[size] = addr;
+  size++;
+
+  if (data.opcode_set){
+     cmdData[size] = data.opcode;
+     size++;
+  }
+
+  for (int i = 0; i < data.parameters.size; i++){
+    cmdData[size] = data.parameters.data[i];
+    size++;
+
+    if (size > TEGRA_CEC_FRAME_MAX_LENGTH){
+      LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Command Longer Than %i Bytes", __func__,TEGRA_CEC_FRAME_MAX_LENGTH);
+      return ADAPTER_MESSAGE_STATE_ERROR;
+    }
+  }
+
+  int status = write(fd,cmdData,size);
+
+  if (status < 0){
+
+    if(errno == ECONNRESET || errno == EHOSTUNREACH){
+      LIB_CEC->AddLog(CEC_LOG_TRAFFIC, "%s: Write OK But Not ACKED (%s)", __func__, strerror(errno));
+      return ADAPTER_MESSAGE_STATE_SENT_NOT_ACKED;
+    } else {
+      LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Write Error (%s)", __func__, strerror(errno));
+      return ADAPTER_MESSAGE_STATE_ERROR;
+    }
+
+  } else {
+    LIB_CEC->AddLog(CEC_LOG_TRAFFIC, "%s: Write OK And ACKED", __func__);
+    return ADAPTER_MESSAGE_STATE_SENT_ACKED;
+  }
+
+}
+
+uint16_t TegraCECAdapterCommunication::GetFirmwareVersion(void)
+{
+  return 0;
+}
+
+cec_vendor_id TegraCECAdapterCommunication::GetVendorId(void)
+{
+   return CEC_VENDOR_LG;
+}
+
+uint16_t TegraCECAdapterCommunication::GetPhysicalAddress(void)
+{
+  uint16_t iPA;
+
+  LIB_CEC->AddLog(CEC_LOG_DEBUG, "%s - trying to get the physical address from the OS", __FUNCTION__);
+  iPA = CEDIDParser::GetPhysicalAddress();
+  LIB_CEC->AddLog(CEC_LOG_DEBUG, "%s - OS returned physical address %04x", __FUNCTION__, iPA);
+
+  return iPA;
+}
+
+cec_logical_addresses TegraCECAdapterCommunication::GetLogicalAddresses(void) const
+{
+  cec_logical_addresses addresses;
+  char logical_str[5] = {0};
+  int logical_int = 0;
+
+  addresses.Clear();
+
+  if (lseek(fdAddr, 0, SEEK_SET) < 0)
+      goto failed;
+
+  if (read(fdAddr, logical_str, sizeof(logical_str) - 1) <= 0)
+      goto failed;
+
+  logical_int = strtol(logical_str, NULL, 16);
+  for (int i = CECDEVICE_TV; i < CECDEVICE_BROADCAST; i++)
+  {
+      if (logical_int & (1<<i))
+          addresses.Set(cec_logical_address(i));
+  }
+
+failed:
+  return addresses;
+}
+
+bool TegraCECAdapterCommunication::SetLogicalAddresses(const cec_logical_addresses &addresses)
+{
+  if (!IsOpen())
+  	  return false;
+
+  uint16_t mask = 0x0;
+  char buf [8] = {0};
+
+  for (int i = CECDEVICE_TV; i < CECDEVICE_BROADCAST; i++)
+  {
+    if (addresses.IsSet(cec_logical_address(i))){
+      mask |= 0x1 << i;
+    }
+  }
+
+  sprintf(buf, "0x%x", mask);
+
+  lseek(fdAddr, 0, SEEK_SET);
+
+  if(write(fdAddr,&buf,sizeof(buf)) < 0){
+    LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Failed write to logical address node (%s) (%i)", __func__,strerror(errno),mask);
+    return false;
+  }
+
+  m_logicalAddresses = addresses;
+  m_bLogicalAddressChanged = true;
+  return true;
+}
+
+void TegraCECAdapterCommunication::HandleLogicalAddressLost(cec_logical_address UNUSED(oldAddress))
+{
+  //Tegra always listens on broadcast so no need to handle this
+}
+
+void *TegraCECAdapterCommunication::Process(void)
+{
+  unsigned char opcode;
+  cec_logical_address initiator, destination;
+
+  while (!IsStopped())
+  {
+
+    int8_t isNotEndOfData = 1;
+    unsigned char buffer[2] = {0,0};
+    cec_command cmd;
+
+    if (read(fd,buffer,2) < 0){
+        LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Failed To Read From Tegra CEC Device", __func__);
+    }
+
+    initiator = cec_logical_address(buffer[0] >> 4);
+    destination = cec_logical_address(buffer[0] & 0x0f);
+
+    if ((buffer[1] & 0x01) > 0){
+      isNotEndOfData = 0;
+    }
+
+    if (isNotEndOfData > 0){
+
+      if (read(fd,buffer,2) < 0){
+        LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Failed To Read From Tegra CEC Device", __func__);
+      }
+
+      opcode = buffer[0];
+      cec_command::Format(cmd, initiator, destination, cec_opcode(opcode));
+      if ((buffer[1] & 0x01) > 0){
+        isNotEndOfData = 0;
+      }
+    } else {
+      cec_command::Format(cmd, initiator, destination, CEC_OPCODE_NONE);
+    }
+
+    while (isNotEndOfData > 0){
+
+      if (read(fd,buffer,2) < 0){
+        LIB_CEC->AddLog(CEC_LOG_ERROR, "%s: Failed To Read From Tegra CEC Device", __func__);
+      }
+
+      cmd.parameters.PushBack(buffer[0]);
+
+      if ((buffer[1] & 0x01) > 0){
+        isNotEndOfData = 0;
+      }
+
+    }
+
+    //LIB_CEC->AddLog(CEC_LOG_TRAFFIC, "%s: Reading Data Len : %i", __func__, cmd.parameters.size);
+    if (!IsStopped())
+      m_callback->OnCommandReceived(cmd);
+  }
+
+  return 0;
+}
+
+#endif

--- a/src/libcec/adapter/Tegra/TegraCECAdapterCommunication.h
+++ b/src/libcec/adapter/Tegra/TegraCECAdapterCommunication.h
@@ -1,0 +1,127 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#if defined(HAVE_TEGRA_API)
+
+#include "p8-platform/threads/mutex.h"
+#include "p8-platform/threads/threads.h"
+#include "p8-platform/sockets/socket.h"
+#include "adapter/AdapterCommunication.h"
+#include <map>
+
+#define TEGRA_ADAPTER_VID 0x0001
+#define TEGRA_ADAPTER_PID 0x0001
+
+namespace P8PLATFORM
+{
+  class CCDevSocket;
+};
+
+
+namespace CEC
+{
+  class CAdapterMessageQueueEntry;
+
+  class TegraCECAdapterCommunication : public IAdapterCommunication, public P8PLATFORM::CThread
+  {
+  public:
+    /*!
+     * @brief Create a new USB-CEC communication handler.
+     * @param callback The callback to use for incoming CEC commands.
+     */
+    TegraCECAdapterCommunication(IAdapterCommunicationCallback *callback);
+    virtual ~TegraCECAdapterCommunication(void);
+
+    /** @name IAdapterCommunication implementation */
+    ///{
+    bool Open(uint32_t iTimeoutMs = CEC_DEFAULT_CONNECT_TIMEOUT, bool bSkipChecks = false, bool bStartListening = true);
+    void Close(void);
+    void writeTegraCEC(unsigned char func, int isStart, int isFinish, int isBroadcast);
+    bool IsOpen(void);
+    std::string GetError(void) const;
+    cec_adapter_message_state Write(const cec_command &data, bool &bRetry, uint8_t iLineTimeout, bool bIsReply);
+
+    bool SetLineTimeout(uint8_t UNUSED(iTimeout)) { return true; }
+    bool StartBootloader(void) { return false; }
+    bool SetLogicalAddresses(const cec_logical_addresses &addresses);
+    cec_logical_addresses GetLogicalAddresses(void) const override;
+    bool PingAdapter(void) { return IsInitialised(); }
+    uint16_t GetFirmwareVersion(void);
+    uint32_t GetFirmwareBuildDate(void) { return 0; }
+    bool IsRunningLatestFirmware(void) { return true; }
+    bool PersistConfiguration(const libcec_configuration & UNUSED(configuration)) { return false; }
+    bool GetConfiguration(libcec_configuration & UNUSED(configuration)) { return false; }
+    std::string GetPortName(void) { return std::string("TEGRACEC"); }
+    uint16_t GetPhysicalAddress(void);
+    bool SetControlledMode(bool UNUSED(controlled)) { return true; }
+	bool SaveConfiguration(const libcec_configuration & UNUSED(configuration)) override { return false; }
+    bool SetAutoMode(bool UNUSED(automode)) override { return false; }
+    cec_vendor_id GetVendorId(void);
+    bool SupportsSourceLogicalAddress(const cec_logical_address address) { return address > CECDEVICE_TV && address <= CECDEVICE_BROADCAST; }
+    cec_adapter_type GetAdapterType(void) { return ADAPTERTYPE_TEGRA; }
+    uint16_t GetAdapterVendorId(void) const { return TEGRA_ADAPTER_VID; }
+    uint16_t GetAdapterProductId(void) const { return TEGRA_ADAPTER_PID; }
+    void HandleLogicalAddressLost(cec_logical_address oldAddress);
+    void SetActiveSource(bool UNUSED(bSetTo), bool UNUSED(bClientUnregistered)) {}
+#if CEC_LIB_VERSION_MAJOR >= 5
+    bool GetStats(struct cec_adapter_stats* UNUSED(stats)) override { return false; }
+#endif
+
+    ///}
+
+    /** @name P8PLATFORM::CThread implementation */
+    ///{
+    void *Process(void);
+    ///}
+
+  private:
+    bool IsInitialised(void) const { return m_dev != 0; };
+    int fd;
+    int fdAddr;
+    bool devOpen;
+    std::string                 m_strError; /**< current error message */
+
+    bool                        m_bLogicalAddressChanged;
+    cec_logical_addresses       m_logicalAddresses;
+
+    P8PLATFORM::CMutex            m_mutex;
+    P8PLATFORM::CCDevSocket       *m_dev;	/**< the device connection */
+    
+    P8PLATFORM::CMutex            m_messageMutex;
+    uint32_t                    m_iNextMessage;
+    std::map<uint32_t, CAdapterMessageQueueEntry *> m_messages;
+  };
+  
+};
+
+#endif

--- a/src/libcec/adapter/Tegra/TegraCECAdapterDetection.cpp
+++ b/src/libcec/adapter/Tegra/TegraCECAdapterDetection.cpp
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+#include "env.h"
+#include <stdio.h>
+
+#if defined(HAVE_TEGRA_API)
+#include "TegraCECAdapterDetection.h"
+#include "TegraCECDev.h"
+
+using namespace CEC;
+
+bool TegraCECAdapterDetection::FindAdapter(void)
+{
+  return access(TEGRA_CEC_DEV_PATH, 0) == 0;
+}
+
+#endif

--- a/src/libcec/adapter/Tegra/TegraCECAdapterDetection.h
+++ b/src/libcec/adapter/Tegra/TegraCECAdapterDetection.h
@@ -1,0 +1,41 @@
+#pragma once
+/*
+ * This file is part of the libCEC(R) library.
+ *
+ * libCEC(R) is Copyright (C) 2011-2013 Pulse-Eight Limited.  All rights reserved.
+ * libCEC(R) is an original work, containing original code.
+ *
+ * libCEC(R) is a trademark of Pulse-Eight Limited.
+ *
+ * This program is dual-licensed; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *
+ * Alternatively, you can license this library under a commercial license,
+ * please contact Pulse-Eight Licensing for more information.
+ *
+ * For more information contact:
+ * Pulse-Eight Licensing       <license@pulse-eight.com>
+ *     http://www.pulse-eight.com/
+ *     http://www.pulse-eight.net/
+ */
+
+namespace CEC
+{
+  class TegraCECAdapterDetection
+  {
+  public:
+    static bool FindAdapter(void);
+  };
+}

--- a/src/libcec/adapter/Tegra/TegraCECDev.h
+++ b/src/libcec/adapter/Tegra/TegraCECDev.h
@@ -1,0 +1,3 @@
+#define TEGRA_CEC_DEV_PATH "/dev/tegra_cec"
+#define TEGRA_CEC_FRAME_MAX_LENGTH  16
+#define TEGRA_ADDR_PATH "/sys/devices/platform/tegra_cec/cec_logical_addr_config"

--- a/src/libcec/cmake/CheckPlatformSupport.cmake
+++ b/src/libcec/cmake/CheckPlatformSupport.cmake
@@ -10,6 +10,7 @@
 #       HAVE_TDA995X_API          ON if TDA995X is supported
 #       HAVE_EXYNOS_API           ON if Exynos is supported
 #       HAVE_LINUX_API            ON if Linux is supported
+#       HAVE_TEGRA_API            ON if Tegra is supported
 #       HAVE_AOCEC_API            ON if AOCEC is supported
 #       HAVE_IMX_API              ON if iMX.6 is supported
 #       HAVE_P8_USB               ON if Pulse-Eight devices are supported
@@ -33,6 +34,7 @@ SET(HAVE_RPI_API         OFF CACHE BOOL "raspberry pi not supported")
 SET(HAVE_TDA995X_API     OFF CACHE BOOL "tda995x not supported")
 SET(HAVE_EXYNOS_API      OFF CACHE BOOL "exynos not supported")
 SET(HAVE_LINUX_API       OFF CACHE BOOL "linux not supported")
+SET(HAVE_TEGRA_API       OFF CACHE BOOL "tegra not supported")
 SET(HAVE_AOCEC_API       OFF CACHE BOOL "aocec not supported")
 # Pulse-Eight devices are always supported
 set(HAVE_P8_USB          ON  CACHE BOOL "p8 usb-cec supported" FORCE)
@@ -162,6 +164,16 @@ else()
                                   adapter/Linux/LinuxCECAdapterCommunication.cpp)
     source_group("Source Files\\adapter\\Linux" FILES ${CEC_SOURCES_ADAPTER_LINUX})
     list(APPEND CEC_SOURCES ${CEC_SOURCES_ADAPTER_LINUX})
+  endif()
+
+  # Tegra
+  if (${HAVE_TEGRA_API})
+    set(LIB_INFO "${LIB_INFO}, Tegra")
+    SET(HAVE_TEGRA_API ON CACHE BOOL "tegra supported" FORCE)
+    set(CEC_SOURCES_ADAPTER_TEGRA adapter/Tegra/TegraCECAdapterDetection.cpp
+                                  adapter/Tegra/TegraCECAdapterCommunication.cpp)
+    source_group("Source Files\\adapter\\Tegra" FILES ${CEC_SOURCES_ADAPTER_TEGRA})
+    list(APPEND CEC_SOURCES ${CEC_SOURCES_ADAPTER_TEGRA})
   endif()
 
   # AOCEC

--- a/src/libcec/cmake/DisplayPlatformSupport.cmake
+++ b/src/libcec/cmake/DisplayPlatformSupport.cmake
@@ -50,6 +50,12 @@ else()
   message(STATUS "Linux support:                          no")
 endif()
 
+if (HAVE_TEGRA_API)
+  message(STATUS "Tegra support:                          yes")
+else()
+  message(STATUS "Tegra support:                          no")
+endif()
+
 if (HAVE_AOCEC_API)
   message(STATUS "AOCEC support:                          yes")
 else()

--- a/src/libcec/env.h.in
+++ b/src/libcec/env.h.in
@@ -82,6 +82,9 @@
 /* Define to 1 for Linux support */
 #cmakedefine HAVE_LINUX_API @HAVE_LINUX_API@
 
+/* Define to 1 for Tegra support */
+#cmakedefine HAVE_TEGRA_API @HAVE_TEGRA_API@
+
 /* Define to 1 for AOCEC support */
 #cmakedefine HAVE_AOCEC_API @HAVE_AOCEC_API@
 

--- a/src/libcec/implementations/SLCommandHandler.cpp
+++ b/src/libcec/implementations/SLCommandHandler.cpp
@@ -385,20 +385,21 @@ bool CSLCommandHandler::ActivateSource(bool bTransmitDelayedCommandsOnly /* = fa
     }
 
     CCECPlaybackDevice *device = m_busDevice->AsPlaybackDevice();
-    if (device)
+    bool bActiveSourceFailed(true);
+    if (device) {
       device->SetDeckStatus(!device->IsActiveSource() ? CEC_DECK_INFO_OTHER_STATUS : CEC_DECK_INFO_OTHER_STATUS_LG);
 
-    // power on the TV
-    CCECBusDevice* tv = m_processor->GetDevice(CECDEVICE_TV);
-    bool bTvPresent = (tv && tv->GetStatus() == CEC_DEVICE_STATUS_PRESENT);
-    bool bActiveSourceFailed(false);
-    if (bTvPresent)
-    {
-      bActiveSourceFailed = !device->TransmitImageViewOn();
-    }
-    else
-    {
-      LIB_CEC->AddLog(CEC_LOG_DEBUG, "TV not present, not sending 'image view on'");
+      // power on the TV
+      CCECBusDevice* tv = m_processor->GetDevice(CECDEVICE_TV);
+      bool bTvPresent = (tv && tv->GetStatus() == CEC_DEVICE_STATUS_PRESENT);
+      if (bTvPresent)
+      {
+        bActiveSourceFailed = !device->TransmitImageViewOn();
+      }
+      else
+      {
+        LIB_CEC->AddLog(CEC_LOG_DEBUG, "TV not present, not sending 'image view on'");
+      }
     }
 
     // check if we're allowed to switch sources

--- a/src/libcec/implementations/SLCommandHandler.cpp
+++ b/src/libcec/implementations/SLCommandHandler.cpp
@@ -385,7 +385,7 @@ bool CSLCommandHandler::ActivateSource(bool bTransmitDelayedCommandsOnly /* = fa
     }
 
     CCECPlaybackDevice *device = m_busDevice->AsPlaybackDevice();
-    bool bActiveSourceFailed(true);
+    bool bActiveSourceFailed(false);
     if (device) {
       device->SetDeckStatus(!device->IsActiveSource() ? CEC_DECK_INFO_OTHER_STATUS : CEC_DECK_INFO_OTHER_STATUS_LG);
 


### PR DESCRIPTION
The original implementation was done by https://github.com/BuzzBumbleBee/libcec for an old version of libcec.

I have updated it for the latest libcec code.
I have tested this with cec-client and with Kodi 20.01.

( Resolves https://github.com/Pulse-Eight/libcec/issues/533 )

A side note:
This code writes to /sys/devices/platform/tegra_cec/cec_logical_addr_config . This file is by default not writable (0644) by a normal user.
Your client (cec-client or kodi) needs to be run as root (not recommended). Or chmod this file to be writable by all users (0666) at startup.