### PR TITLE
[libcec] fix incorrect preprocessor command

### DIFF
--- a/src/libcec/LibCEC.cpp
+++ b/src/libcec/LibCEC.cpp
@@ -532,7 +532,7 @@ const char *CLibCEC::GetLibInfo(void)
 #define FEATURES "'P8 USB' 'P8 USB detect'"
 #if defined(_WIN64)
 #define HOST_TYPE "Windows (x64)"
-#elseif defined(_M_ARM64)
+#elif defined(_M_ARM64)
 #define HOST_TYPE "Windows (ARM64)"
 #else
 #define HOST_TYPE "Windows (x86)"


### PR DESCRIPTION
commit 65905e1 introduced the below warning

```
/src/libcec/LibCEC.cpp:535:2: warning: invalid preprocessing directive, did you mean '#elif'? [-Wunknown-directives]
  535 | #elseif defined(_M_ARM64)
      |  ^~~~~~
      |  elif
1 warning generated.
```