### PR TITLE
RPiCECAdapterDetection: Include check that we can set passive mode

### DIFF
--- a/src/libcec/adapter/RPi/RPiCECAdapterDetection.cpp
+++ b/src/libcec/adapter/RPi/RPiCECAdapterDetection.cpp
@@ -39,6 +39,7 @@
 extern "C" {
 #include <interface/vmcs_host/vc_cecservice.h>
 #include <interface/vchiq_arm/vchiq_if.h>
+#include <bcm_host.h>
 }
 
 using namespace CEC;
@@ -54,6 +55,10 @@ bool CRPiCECAdapterDetection::FindAdapter(void)
   if ((iResult = vchi_connect(NULL, 0, vchiq_instance)) != VCHIQ_SUCCESS)
     return false;
 
+  bcm_host_init();
+  iResult = vc_cec_set_passive(true);
+  if (iResult != VCHIQ_SUCCESS)
+    return false;
   return true;
 }
 


### PR DESCRIPTION
This allows the firmware driver to be discounted when not available (e.g. using KMS driver) (original commit by popcornmix popcornmix@b30fc83)

this is the RPiCECAdapterDetection part of https://github.com/Pulse-Eight/libcec/pull/672