### PR TITLE
fix physical address auto detection

### DIFF
--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -214,7 +214,12 @@ bool CCECClient::SetHDMIPort(const cec_logical_address iBaseDevice, const uint8_
     }
   }
 
-  return SetPhysicalAddress(iPhysicalAddress);
+  // and set the address
+  SetDevicePhysicalAddress(iPhysicalAddress);
+
+  QueueConfigurationChanged(m_configuration);
+
+  return bReturn;
 }
 
 void CCECClient::ResetPhysicalAddress(void)
@@ -269,11 +274,6 @@ bool CCECClient::SetPhysicalAddress(const libcec_configuration &configuration)
 
 bool CCECClient::SetPhysicalAddress(const uint16_t iPhysicalAddress)
 {
-  if (m_configuration.iPhysicalAddress == iPhysicalAddress)
-  {
-    return true;
-  }
-
   // update the configuration
   {
     CLockObject lock(m_mutex);


### PR DESCRIPTION
Caused by https://github.com/Pulse-Eight/libcec/commit/05fc6d01e6e3f01164f3e844f88ece4bf19e16c9
Issue: https://github.com/Pulse-Eight/libcec/issues/679

It works again with these changes:
https://paste.coreelec.org/TrumanGaston

The remove of `m_configuration.iPhysicalAddress == iPhysicalAddress` is because it's double, just a few lines below.