### PR TITLE
fixed: OnRegister clears baseDevice when physical address already resolved

### DIFF
--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -136,8 +136,10 @@ bool CCECClient::OnRegister(void)
     (*it)->SetMenuLanguage(std::string(m_configuration.strDeviceLanguage, 3));
   }
 
-  // set the physical address
-  SetPhysicalAddress(m_configuration);
+  // set the physical address, unless already resolved (e.g. via SetHDMIPort during RegisterClient)
+  if (!CLibCEC::IsValidPhysicalAddress(m_configuration.iPhysicalAddress) ||
+      m_configuration.iPhysicalAddress == CEC_PHYSICAL_ADDRESS_TV)
+    SetPhysicalAddress(m_configuration);
 
   // make the primary device the active source if the option is set
   if (m_configuration.bActivateSource == 1)


### PR DESCRIPTION
During `RegisterClient`, `SetConfiguration` calls `SetHDMIPort(baseDevice, port)` which resolves the physical address and stores `baseDevice` (e.g. `CECDEVICE_AUDIOSYSTEM`). Then `OnRegister` calls `SetPhysicalAddress(m_configuration)` again, but since `iPhysicalAddress` is already valid from the earlier resolution, it takes the "provided physical address" path which zeroes out `baseDevice` and `iHDMIPort`:

https://github.com/Pulse-Eight/libcec/blob/libcec-7.1.1/src/libcec/CECClient.cpp#L229-L240
```cpp
// CECClient.cpp:229 - SetPhysicalAddress(const libcec_configuration&)
// iPhysicalAddress was already set to 0x2100 by SetHDMIPort above,
// so this branch is taken and baseDevice gets wiped
if (CLibCEC::IsValidPhysicalAddress(configuration.iPhysicalAddress) &&
  (configuration.iPhysicalAddress != CEC_PHYSICAL_ADDRESS_TV) &&
  SetPhysicalAddress(configuration.iPhysicalAddress))
{
  if (m_configuration.bAutodetectAddress == 0)
    LIB_CEC->AddLog(CEC_LOG_DEBUG, "using provided physical address %04X", configuration.iPhysicalAddress);
  CLockObject lock(m_mutex);
  m_configuration.baseDevice       = CECDEVICE_UNKNOWN;         // was CECDEVICE_AUDIOSYSTEM
  m_configuration.iHDMIPort        = CEC_HDMI_PORTNUMBER_NONE;  // was 1
  m_configuration.iPhysicalAddress = configuration.iPhysicalAddress;
  return true;
}
```

After `OnRegister` returns, `m_configuration.baseDevice` is `CECDEVICE_UNKNOWN`. Kodi reads this back via `GetCurrentConfiguration` right after `Open()` completes, interprets it as "connected to TV", and persists that to its settings. Next boot, Kodi passes `CECDEVICE_TV` instead of `CECDEVICE_AUDIOSYSTEM` to `SetHDMIPort`, gets the wrong physical address, and CEC stops working.

The fix skips the `SetPhysicalAddress` call in `OnRegister` when the address is already resolved. No change to `SetPhysicalAddress` itself.

Tested on LibreELEC 12.2.1 with Pulse-Eight USB adapter behind a Yamaha AVR, `baseDevice` stays correct across reboots.

Related: https://forum.libreelec.tv/thread/30065-x86-64-cec-broke-after-updating-to-le-12-2-0/, #679, #687, #698, #699
