### PR TITLE
Fix compiler warnings and potential overflows in cecc-client and libcec

### DIFF
--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -514,7 +514,10 @@ int main(int argc, char *argv[])
       {
         printf("\n path:     %s\n com port: %s\n\n", devices[0].path, devices[0].comm);
       }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
       snprintf(g_strPort, sizeof(g_strPort), "%s", devices[0].comm);
+#pragma GCC diagnostic pop
     }
   }
 

--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -275,7 +275,7 @@ static int cec_process_command_line_arguments(int argc, char *argv[])
       {
         if (argc >= iArgPtr + 2)
         {
-          snprintf(g_config.strDeviceName, 13, "%s", argv[iArgPtr + 1]);
+          snprintf(g_config.strDeviceName, sizeof(g_config.strDeviceName), "%s", argv[iArgPtr + 1]);
           printf("using osd name '%s'\n", g_config.strDeviceName);
           ++iArgPtr;
         }

--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -290,7 +290,7 @@ static int cec_process_command_line_arguments(int argc, char *argv[])
       }
       else
       {
-        strcpy(g_strPort, argv[iArgPtr++]);
+        snprintf(g_strPort, sizeof(g_strPort), "%s", argv[iArgPtr++]);
       }
     }
   }
@@ -514,7 +514,7 @@ int main(int argc, char *argv[])
       {
         printf("\n path:     %s\n com port: %s\n\n", devices[0].path, devices[0].comm);
       }
-      strcpy(g_strPort, devices[0].comm);
+      snprintf(g_strPort, sizeof(g_strPort), "%s", devices[0].comm);
     }
   }
 

--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -428,18 +428,15 @@ static int cec_process_command_scan(const char* data)
 
 static int cec_process_console_command(const char* buffer)
 {
-  size_t buflen;
-  buflen = strlen(buffer);
-
   if (strncmp(buffer, "q", 1) == 0 || strncmp(buffer, "quit", 4) == 0)
     return 0;
 
-  cec_process_command_as(buffer) ||
-  cec_process_command_ea(buffer) ||
-  cec_process_command_da(buffer) ||
-  cec_process_command_gas(buffer) ||
-  cec_process_command_gsam(buffer) ||
-  cec_process_command_scan(buffer);
+  (void)(cec_process_command_as(buffer) ||
+         cec_process_command_ea(buffer) ||
+         cec_process_command_da(buffer) ||
+         cec_process_command_gas(buffer) ||
+         cec_process_command_gsam(buffer) ||
+         cec_process_command_scan(buffer));
   //TODO
 
   return 1;

--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -107,6 +107,7 @@ static void cb_cec_log_message(void* lib, const cec_log_message* message)
       strLevel = "DEBUG:   ";
       break;
     default:
+      strLevel = "UNKNOWN: ";
       break;
     }
 

--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -1330,7 +1330,10 @@ void CCECClient::SetOSDName(const std::string &strDeviceName)
     snprintf(buf, sizeof(buf), "%s", strDeviceName.c_str());
     if (!strncmp(m_configuration.strDeviceName, buf, LIBCEC_OSD_NAME_SIZE))
       return;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
     snprintf(m_configuration.strDeviceName, sizeof(m_configuration.strDeviceName), "%s", buf);
+#pragma GCC diagnostic pop
     LIB_CEC->AddLog(CEC_LOG_DEBUG, "%s - using OSD name '%s'", __FUNCTION__, buf);
   }
 

--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -1326,11 +1326,11 @@ void CCECClient::SetOSDName(const std::string &strDeviceName)
 {
   {
     CLockObject lock(m_mutex);
-    char buf[LIBCEC_OSD_NAME_SIZE + 1] = { 0 };
-    strncpy(buf, strDeviceName.c_str(), LIBCEC_OSD_NAME_SIZE);
+    char buf[LIBCEC_OSD_NAME_SIZE + 1];
+    snprintf(buf, sizeof(buf), "%s", strDeviceName.c_str());
     if (!strncmp(m_configuration.strDeviceName, buf, LIBCEC_OSD_NAME_SIZE))
       return;
-    strncpy(m_configuration.strDeviceName, buf, LIBCEC_OSD_NAME_SIZE);
+    snprintf(m_configuration.strDeviceName, sizeof(m_configuration.strDeviceName), "%s", buf);
     LIB_CEC->AddLog(CEC_LOG_DEBUG, "%s - using OSD name '%s'", __FUNCTION__, buf);
   }
 

--- a/src/libcec/adapter/AdapterFactory.cpp
+++ b/src/libcec/adapter/AdapterFactory.cpp
@@ -87,8 +87,8 @@ int8_t CAdapterFactory::FindAdapters(cec_adapter *deviceList, uint8_t iBufSize, 
   int8_t iReturn = DetectAdapters(devices, iBufSize, strDevicePath);
   for (int8_t iPtr = 0; iPtr < iReturn && iPtr < iBufSize; iPtr++)
   {
-    strncpy(deviceList[iPtr].comm, devices[iPtr].strComName, sizeof(deviceList[iPtr].comm));
-    strncpy(deviceList[iPtr].path, devices[iPtr].strComPath, sizeof(deviceList[iPtr].path));
+    snprintf(deviceList[iPtr].comm, sizeof(deviceList[iPtr].comm), "%s", devices[iPtr].strComName);
+    snprintf(deviceList[iPtr].path, sizeof(deviceList[iPtr].path), "%s", devices[iPtr].strComPath);
   }
   return iReturn;
 }

--- a/src/libcec/adapter/AdapterFactory.cpp
+++ b/src/libcec/adapter/AdapterFactory.cpp
@@ -88,7 +88,10 @@ int8_t CAdapterFactory::FindAdapters(cec_adapter *deviceList, uint8_t iBufSize, 
   for (int8_t iPtr = 0; iPtr < iReturn && iPtr < iBufSize; iPtr++)
   {
     snprintf(deviceList[iPtr].comm, sizeof(deviceList[iPtr].comm), "%s", devices[iPtr].strComName);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
     snprintf(deviceList[iPtr].path, sizeof(deviceList[iPtr].path), "%s", devices[iPtr].strComPath);
+#pragma GCC diagnostic pop
   }
   return iReturn;
 }


### PR DESCRIPTION
Fixes a series of compiler warnings across cecc-client.c, AdapterFactory.cpp,
and CECClient.cpp.

- Use snprintf instead of strncpy for fixed-buffer copies in FindAdapters
- Use snprintf instead of strncpy in CCECClient::SetOSDName
- Initialise strLevel in default case of cb_cec_log_message
- Fix unused variable and discarded value warnings in cec_process_console_command
- Replace strcpy with snprintf when copying into g_strPort
- Use sizeof instead of magic number 13 in snprintf for strDeviceName
- Suppress -Wformat-truncation at intentional snprintf truncation sites

issues were found when compiling on Ubuntu 26.04 with gcc-16