### PR TITLE
Fix sizeof array element count in find_adapters call

### DIFF
--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -501,7 +501,7 @@ int main(int argc, char *argv[])
     if (!g_bSingleCommand)
       printf("no serial port given. trying autodetect: ");
 
-    iDevicesFound = g_iface.find_adapters(g_iface.connection, devices, sizeof(devices) / sizeof(devices), NULL);
+    iDevicesFound = g_iface.find_adapters(g_iface.connection, devices, sizeof(devices) / sizeof(devices[0]), NULL);
     if (iDevicesFound <= 0)
     {
       if (g_bSingleCommand)


### PR DESCRIPTION
sizeof(devices) / sizeof(devices) always evaluated to 1, passing the wrong adapter count to find_adapters. Changed to sizeof(devices[0]) to correctly compute the number of elements.
- fixes #709 

matches intent in:
https://github.com/Pulse-Eight/libcec/blob/c7c4c82dc171c49decfbfe5d2959706d3e2ea47c/src/cec-client/cec-client.cpp#L1391