### PR TITLE
Add -c/--command option to cec-client

### DIFF
--- a/src/cec-client/cec-client.cpp
+++ b/src/cec-client/cec-client.cpp
@@ -64,6 +64,7 @@ std::ofstream         g_logOutput;
 bool                  g_bShortLog(false);
 std::string           g_strPort;
 bool                  g_bSingleCommand(false);
+std::string           g_strCommand;
 volatile sig_atomic_t g_bExit(0);
 bool                  g_bHardExit(false);
 CMutex                g_outputMutex;
@@ -312,6 +313,8 @@ void ShowHelpCommandLine(const char* strExec)
       "  -d --log-level {level}      Sets the log level. See cectypes.h for values." << std::endl <<
       "  -s --single-command         Execute a single command and exit. Does not power" << std::endl <<
       "                              on devices on startup and power them off on exit." << std::endl <<
+      "  -c --command {command}      Execute a single given command and exit. (Implies" << std::endl <<
+      "                              --single-command)" << std::endl <<
       "  -o --osd-name {osd name}    Use a custom osd name." << std::endl <<
       "  -m --monitor                Start a monitor-only client." << std::endl <<
       "  -i --info                   Shows information about how libCEC was compiled." << std::endl <<
@@ -1192,6 +1195,17 @@ bool ProcessCommandLineArguments(int argc, char *argv[])
         g_bSingleCommand = true;
         ++iArgPtr;
       }
+      else if (!strcmp(argv[iArgPtr], "--command") ||
+          !strcmp(argv[iArgPtr], "-c"))
+      {
+        if (argc >= iArgPtr + 2)
+        {
+          g_strCommand = argv[iArgPtr + 1];
+          g_bSingleCommand = true;
+          ++iArgPtr;
+        }
+        ++iArgPtr;
+      }
       else if (!strcmp(argv[iArgPtr], "--help") ||
                !strcmp(argv[iArgPtr], "-h"))
       {
@@ -1428,19 +1442,26 @@ int main (int argc, char *argv[])
   while (!g_bExit && !g_bHardExit)
   {
     std::string input;
-#if defined(HAVE_CURSES_API)
-    if (!g_cursesEnable) {
-      getline(std::cin, input);
-      std::cin.clear();
+    if (!g_strCommand.empty())
+    {
+      input = g_strCommand;
     }
     else
     {
-      input = g_cursesControl.ParseCursesKey();
-    }
+#if defined(HAVE_CURSES_API)
+      if (!g_cursesEnable) {
+        getline(std::cin, input);
+        std::cin.clear();
+      }
+      else
+      {
+        input = g_cursesControl.ParseCursesKey();
+      }
 #else
-    getline(std::cin, input);
-    std::cin.clear();
+      getline(std::cin, input);
+      std::cin.clear();
 #endif
+    }
 
     if (ProcessConsoleCommand(g_parser, input) && !g_bSingleCommand && !g_bExit && !g_bHardExit)
     {

--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -69,11 +69,14 @@ static ICECCallbacks        g_callbacks = {
     .commandHandler       = NULL
 };
 
+#define MAX_CMDSZ 100
+
 static libcec_configuration  g_config;
 static int                   g_cecLogLevel = -1;
 static int                   g_cecDefaultLogLevel = CEC_LOG_ALL;
 static char                  g_strPort[50] = { 0 };
 static int                   g_bSingleCommand = 0;
+static char                  g_strCommand[MAX_CMDSZ] = { 0 };
 static volatile sig_atomic_t g_bExit = 0;
 static int                   g_bHardExit = 0;
 static libcec_interface_t    g_iface;
@@ -224,6 +227,17 @@ static int cec_process_command_line_arguments(int argc, char *argv[])
           !strcmp(argv[iArgPtr], "-s"))
       {
         g_bSingleCommand = 1;
+        ++iArgPtr;
+      }
+      else if (!strcmp(argv[iArgPtr], "--command") ||
+          !strcmp(argv[iArgPtr], "-c"))
+      {
+        if (argc >= iArgPtr + 2)
+        {
+          strcpy(g_strCommand, argv[iArgPtr + 1]);
+          g_bSingleCommand = 1;
+          ++iArgPtr;
+        }
         ++iArgPtr;
       }
       else if (!strcmp(argv[iArgPtr], "--help") ||
@@ -446,7 +460,7 @@ static int cec_process_console_command(const char* buffer)
 
 int main(int argc, char *argv[])
 {
-  char buffer[100];
+  char buffer[MAX_CMDSZ];
   if (signal(SIGINT, sighandler) == SIG_ERR)
   {
     printf("can't register sighandler\n");
@@ -535,7 +549,14 @@ int main(int argc, char *argv[])
   while (!g_bExit && !g_bHardExit)
   {
     memset(buffer, 0, sizeof(buffer));
-    fgets(buffer, sizeof(buffer), stdin);
+    if (g_strCommand[0] != 0)
+    {
+      strcpy(buffer, g_strCommand);
+    }
+    else
+    {
+      fgets(buffer, sizeof(buffer), stdin);
+    }
 
     if (cec_process_console_command(buffer) && !g_bSingleCommand && !g_bExit && !g_bHardExit)
     {


### PR DESCRIPTION
When reading example use-cases for cec-client, I was surprised that they always piped the input into the binary[^1][^2][^3].

This change adds a -c flag to cec(c)-client to allow specifying that command, analogous to "sh -c".

[^1]: https://stackoverflow.com/questions/17506515/set-active-source-to-tv-with-cec-client
[^2]: https://raspberrypi.stackexchange.com/questions/9142/commands-for-using-cec-client
[^3]: https://gist.github.com/rmtsrc/dc35cd1458cd995631a4f041ab11ff74