### PR TITLE
Add configurable device vendor ID (libcec_configuration.iDeviceVendorId)

### DIFF
--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -1530,6 +1530,7 @@ struct libcec_configuration
 #if CEC_LIB_VERSION_MAJOR >= 5
   uint8_t               bAutoPowerOn;         /*!< set to 1 and save eeprom config to wake the tv when usb is powered. added in 5.0.0 / fw v9 */
 #endif
+  uint32_t              iDeviceVendorId;      /*!< the vendor ID to announce for this device. CEC_VENDOR_UNKNOWN (default) to keep libCEC's default identity. added in 7.2.0 */
 
 #ifdef __cplusplus
    libcec_configuration(void) { Clear(); }
@@ -1563,7 +1564,8 @@ struct libcec_configuration
                  iButtonReleaseDelayMs     == other.iButtonReleaseDelayMs &&
                  comboKey                  == other.comboKey &&
                  iComboKeyTimeoutMs        == other.iComboKeyTimeoutMs &&
-                 bAutoWakeAVR              == other.bAutoWakeAVR
+                 bAutoWakeAVR              == other.bAutoWakeAVR &&
+                 iDeviceVendorId           == other.iDeviceVendorId
 #if CEC_LIB_VERSION_MAJOR >= 5
               && bAutoPowerOn              == other.bAutoPowerOn
 #endif
@@ -1605,6 +1607,7 @@ struct libcec_configuration
 #if CEC_LIB_VERSION_MAJOR >= 5
     bAutoPowerOn =                    2;
 #endif
+    iDeviceVendorId =       (uint32_t)CEC_VENDOR_UNKNOWN;
 
     strDeviceName[0] = (char)0;
     deviceTypes.Clear();

--- a/src/cec-client/cec-client.cpp
+++ b/src/cec-client/cec-client.cpp
@@ -317,6 +317,8 @@ void ShowHelpCommandLine(const char* strExec)
       "  -c --command {command}      Execute a single given command and exit. (Implies" << std::endl <<
       "                              --single-command)" << std::endl <<
       "  -o --osd-name {osd name}    Use a custom osd name." << std::endl <<
+      "  --vendor-id {id}            The CEC vendor ID to announce for this device," << std::endl <<
+      "                              as up to 6 hex digits (e.g. 00e091)." << std::endl <<
       "  -m --monitor                Start a monitor-only client." << std::endl <<
       "  -i --info                   Shows information about how libCEC was compiled." << std::endl <<
       "  [COM PORT]                  The com port to connect to. If no COM" << std::endl <<
@@ -1275,6 +1277,25 @@ bool ProcessCommandLineArguments(int argc, char *argv[])
       {
         std::cout << "starting a monitor-only client. use 'mon 0' to switch to normal mode" << std::endl;
         g_config.bMonitorOnly = 1;
+        ++iArgPtr;
+      }
+      else if (!strcmp(argv[iArgPtr], "--vendor-id"))
+      {
+        if (argc >= iArgPtr + 2)
+        {
+          char* end = NULL;
+          unsigned long iVendorId = strtoul(argv[iArgPtr + 1], &end, 16);
+          if (end && *end == '\0' && iVendorId <= 0xFFFFFF)
+          {
+            g_config.iDeviceVendorId = (uint32_t)iVendorId;
+            std::cout << "using vendor id '" << argv[iArgPtr + 1] << "'" << std::endl;
+          }
+          else
+          {
+            std::cout << "== skipped invalid vendor id '" << argv[iArgPtr + 1] << "' ==" << std::endl;
+          }
+          ++iArgPtr;
+        }
         ++iArgPtr;
       }
 #if defined(HAVE_CURSES_API)

--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -882,6 +882,7 @@ bool CCECClient::GetCurrentConfiguration(libcec_configuration &configuration)
 #if CEC_LIB_VERSION_MAJOR >= 5
   configuration.bAutoPowerOn              = m_configuration.bAutoPowerOn;
 #endif
+  configuration.iDeviceVendorId           = m_configuration.iDeviceVendorId;
 
   return true;
 }
@@ -933,6 +934,7 @@ bool CCECClient::SetConfiguration(const libcec_configuration &configuration)
     if ((configuration.bAutoPowerOn == 0) || (configuration.bAutoPowerOn == 1))
       m_configuration.bAutoPowerOn             = configuration.bAutoPowerOn;
 #endif
+    m_configuration.iDeviceVendorId            = configuration.iDeviceVendorId;
 
     if (activeSourceChanged)
     {

--- a/src/libcec/adapter/Linux/LinuxCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/Linux/LinuxCECAdapterCommunication.cpp
@@ -53,6 +53,19 @@ using namespace P8PLATFORM;
 // Required capabilities
 #define CEC_LINUX_CAPABILITIES (CEC_CAP_LOG_ADDRS | CEC_CAP_TRANSMIT | CEC_CAP_PASSTHROUGH)
 
+// The vendor ID to register with the CEC framework - the kernel announces it
+// in a <Device Vendor ID> broadcast at every logical address claim, so use
+// the configured vendor ID (when set) to keep the announced identity
+// consistent with what the client wants to present on the bus.
+static uint32_t GetConfiguredVendorId(IAdapterCommunicationCallback *callback)
+{
+  libcec_configuration config;
+  if (callback && callback->GetLib() && callback->GetLib()->GetCurrentConfiguration(&config) &&
+      config.iDeviceVendorId != (uint32_t)CEC_VENDOR_UNKNOWN)
+    return config.iDeviceVendorId;
+  return CEC_VENDOR_PULSE_EIGHT;
+}
+
 CLinuxCECAdapterCommunication::CLinuxCECAdapterCommunication(IAdapterCommunicationCallback *callback)
   : IAdapterCommunication(callback)
 {
@@ -124,7 +137,7 @@ bool CLinuxCECAdapterCommunication::Open(uint32_t UNUSED(iTimeoutMs), bool UNUSE
     // Set logical address to unregistered, without any logical address configured no messages is transmitted or received
     log_addrs = {};
     log_addrs.cec_version = CEC_OP_CEC_VERSION_1_4;
-    log_addrs.vendor_id = CEC_VENDOR_PULSE_EIGHT;
+    log_addrs.vendor_id = GetConfiguredVendorId(m_callback);
     log_addrs.num_log_addrs = 1;
     log_addrs.flags = CEC_LOG_ADDRS_FL_ALLOW_UNREG_FALLBACK;
     log_addrs.log_addr[0] = CEC_LOG_ADDR_UNREGISTERED;
@@ -236,7 +249,7 @@ bool CLinuxCECAdapterCommunication::SetLogicalAddresses(const cec_logical_addres
       // NOTE: This can only be configured when num_log_addrs > 0
       //       and gets reset when num_log_addrs = 0
       log_addrs.cec_version = CEC_OP_CEC_VERSION_1_4;
-      log_addrs.vendor_id = CEC_VENDOR_PULSE_EIGHT;
+      log_addrs.vendor_id = GetConfiguredVendorId(m_callback);
 
       // TODO: Support more then the primary logical address
       log_addrs.num_log_addrs = 1;

--- a/src/libcec/devices/CECBusDevice.cpp
+++ b/src/libcec/devices/CECBusDevice.cpp
@@ -884,6 +884,18 @@ void CCECBusDevice::SetDeviceStatus(const cec_bus_device_status newStatus, cec_v
   if (m_iLogicalAddress == CECDEVICE_UNREGISTERED)
     return;
 
+  // the vendor ID to present for devices handled by libCEC. resolved before
+  // taking the device lock, since it queries the client configuration
+  uint64_t iVendorId(CEC_VENDOR_PULSE_EIGHT);
+  if (newStatus == CEC_DEVICE_STATUS_HANDLED_BY_LIBCEC)
+  {
+    libcec_configuration config;
+    CECClientPtr client = m_processor->GetPrimaryClient();
+    if (client && client->GetCurrentConfiguration(config) &&
+        config.iDeviceVendorId != (uint32_t)CEC_VENDOR_UNKNOWN)
+      iVendorId = config.iDeviceVendorId;
+  }
+
   {
     CLockObject lock(m_mutex);
     switch (newStatus)
@@ -892,7 +904,7 @@ void CCECBusDevice::SetDeviceStatus(const cec_bus_device_status newStatus, cec_v
       if (m_deviceStatus != newStatus)
         LIB_CEC->AddLog(CEC_LOG_DEBUG, "%s (%X): device status changed into 'handled by libCEC'", GetLogicalAddressName(), m_iLogicalAddress);
       SetPowerStatus   (CEC_POWER_STATUS_ON);
-      SetVendorId      (CEC_VENDOR_PULSE_EIGHT);
+      SetVendorId      (iVendorId);
       SetMenuState     (CEC_MENU_STATE_ACTIVATED);
       SetCecVersion    (libCECSpecVersion);
       SetStreamPath    (CEC_INVALID_PHYSICAL_ADDRESS);


### PR DESCRIPTION
libCEC hardcodes `CEC_VENDOR_PULSE_EIGHT` as the identity of the devices it handles — the Linux adapter registers it via `CEC_ADAP_S_LOG_ADDRS` (the kernel then broadcasts `<Device Vendor ID>` with it at every logical-address claim), and devices handled by libCEC answer `<Give Device Vendor ID>` with it until a vendor-specific handler replaces the default.

Some TVs key protocol features on that identity. The reproducible case is LG SIMPLINK: the TV only forwards remote keys to devices whose vendor ID reads LG (`0x00e091`), queries the vendor ~200 ms after a device appears — before the SL handler is installed — and caches the first answer per logical address, so the built-in LG masquerade loses the race and the device never receives remote keys.

This adds `iDeviceVendorId` to `libcec_configuration` (default `CEC_VENDOR_UNKNOWN` = current behavior) so an application can present a consistent vendor identity from the first bus transaction, plus a `--vendor-id` option in cec-client.

### Changes
- `libcec_configuration.iDeviceVendorId` (new field, default `CEC_VENDOR_UNKNOWN`), copied in `CCECClient::Get/SetConfiguration`.
- Linux adapter (`CEC_ADAP_S_LOG_ADDRS` in `Open()` and `SetLogicalAddresses()`) announces the configured vendor when set, otherwise `CEC_VENDOR_PULSE_EIGHT` as before.
- `CCECBusDevice::SetDeviceStatus(CEC_DEVICE_STATUS_HANDLED_BY_LIBCEC)` uses the configured vendor for own devices, so `<Give Device Vendor ID>` replies match from the first transaction.
- `cec-client --vendor-id <hex>` to set it from the CLI.

### Validation
Tested on a Raspberry Pi 5 (vc4_hdmi, kernel CEC API, kernel 6.18) against an LG TV where the race reproduces deterministically: with `--vendor-id e091` the TV completes the SIMPLINK handshake and forwards remote keys; without it it probes forever and forwards nothing. Default behavior is unchanged when `iDeviceVendorId` is left at `CEC_VENDOR_UNKNOWN`.
