### PR TITLE
fix(rpi): fix copy-paste error in VC_CEC_BUTTON_RELEASE handling

### DIFF
--- a/src/libcec/adapter/RPi/RPiCECAdapterCommunication.cpp
+++ b/src/libcec/adapter/RPi/RPiCECAdapterCommunication.cpp
@@ -207,7 +207,7 @@ void CRPiCECAdapterCommunication::OnDataReceived(uint32_t header, uint32_t p0, u
       cec_command::Format(command,
                           (cec_logical_address)CEC_CB_INITIATOR(p0),
                           (cec_logical_address)CEC_CB_FOLLOWER(p0),
-                          reason == VC_CEC_BUTTON_PRESSED ? CEC_OPCODE_USER_CONTROL_RELEASE : CEC_OPCODE_VENDOR_REMOTE_BUTTON_UP);
+                          reason == VC_CEC_BUTTON_RELEASE ? CEC_OPCODE_USER_CONTROL_RELEASE : CEC_OPCODE_VENDOR_REMOTE_BUTTON_UP);
       command.parameters.PushBack((uint8_t)CEC_CB_OPERAND1(p0));
 
       // send to libCEC


### PR DESCRIPTION
We previously tested for `VC_CEC_BUTTON_PRESSED`, which can never match in the "released" branch of the switch. This was probably a copy-paste from the "pressed" branch. Because of this both release types were emitted as vendor-specific `CEC_OPCODE_VENDOR_REMOTE_BUTTON_UP` events, and never `CEC_OPCODE_USER_CONTROL_RELEASE`.