### PR TITLE
Increase default button timeout to 1000 milliseconds

### DIFF
--- a/include/cectypes.h
+++ b/include/cectypes.h
@@ -79,7 +79,7 @@ namespace CEC {
 /*!
  * timeout in milliseconds to send a key release event after receiving a key press
  */
-#define CEC_BUTTON_TIMEOUT           500
+#define CEC_BUTTON_TIMEOUT           1000
 
 /*!
  * don't send the same key twice within this timeout in milliseconds


### PR DESCRIPTION
Many interfaces make use of long-press of buttons, for example to open context menus. 

Auto-releasing buttons after just 500 ms is too short for most applications to detect this as a long-press.

This change makes the default auto-release timeout long enough to not interfere with UIs that need long-press.

I am aware that this default has been like that for a long time, but I still think it is not a good default and, given we are going to release a new major version, it's a good opportunity to change it.