### PR TITLE
fixed: build the Python wrapper against SWIG 4.5

### DIFF
--- a/src/libcec/SwigHelper.h
+++ b/src/libcec/SwigHelper.h
@@ -137,8 +137,17 @@ namespace CEC
           Py_DECREF(arglist);
         if (!!result)
         {
+          /** SWIG 4.5 removed the PyInt_* compatibility macros it used to define
+              for Python 3, so call the version-appropriate API directly. Note that
+              a Python 2 int is a PyIntObject, not a PyLongObject, so PyLong_Check
+              would silently reject it there. */
+          #if (PY_MAJOR_VERSION < 3)
           if (PyInt_Check(result))
             retval = (int)PyInt_AsLong(result);
+          #else // (PY_MAJOR_VERSION >= 3)
+          if (PyLong_Check(result))
+            retval = (int)PyLong_AsLong(result);
+          #endif
           Py_XDECREF(result);
         }
       }

--- a/src/libcec/libcec.i
+++ b/src/libcec/libcec.i
@@ -11,10 +11,6 @@
 
 %ignore *::operator=;
 
-%typemap(out) CEC::cec_osd_name {
-  $result = PyString_FromString($1.name);
-}
-
 /////// libcec_configuration::strDeviceLanguage ///////
 // strDeviceLanguage is a raw, fixed-size char[3] that is NOT NUL-terminated (a
 // 3-character ISO 639-2 code). SWIG's default char[ANY] setter reserves a byte


### PR DESCRIPTION
SWIG 4.5 removed the Python 2 compatibility macros (`PyInt_*`, `PyString_*`, `SWIG_Python_str_*`) that `pyhead.swg` defined for user typemaps ([swig/swig@79f7a2b](https://github.com/swig/swig/commit/79f7a2b7cb7ddc256eba09c8770133148025171d)). Three lines in this tree used them, and they are all ours rather than generated code:

- `src/libcec/libcec.i` — `PyString_FromString` in the `cec_osd_name` out-typemap
- `src/libcec/SwigHelper.h` — `PyInt_Check` / `PyInt_AsLong` on the callback return value

Both now call the Python 3 API directly. On SWIG 4.4 and older the removed macros expanded to exactly these functions, so for a Python 3 build the change is a no-op after preprocessing, and there is no minimum SWIG or minimum Python 3 version introduced.

Both sites keep a `PY_MAJOR_VERSION` guard rather than replacing the calls unconditionally. The x86 Windows build still forces Python 2 for the EventGhost plugin (`src/libcec/cmake/CheckPlatformSupport.cmake`, `src/pyCecClient/CMakeLists.txt`), and a Python 2 `int` is a `PyIntObject`, not a `PyLongObject` — an unguarded `PyLong_Check` would compile there and then silently read every `commandHandler` and `menuStateChanged` return value as 0, which is the one thing those two callbacks exist to report.

Not compile-tested locally: no SWIG 4.5 here, and configuring a build regenerates the shared `env.h` in the source tree. Needs CI on both the normal x64 path and the x86/EventGhost path that exercises the Python 2 branch.

closes #726