### PR TITLE
debian: drop the undefined ${shlibs:Depends} from the libcec meta package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -100,6 +100,7 @@ Description: Node.js binding for libCEC
 
 Package: libcec
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libcec8 (= ${binary:Version})
+Depends: libcec8 (= ${binary:Version}),
+         ${misc:Depends}
 Description: Meta package libCEC.
 


### PR DESCRIPTION
**Fixes #731.**

The `libcec` meta package ships no binaries — it has no `.install` file — so `dpkg-shlibdeps` never runs for it and never defines `${shlibs:Depends}`, which `dpkg-gencontrol` warns about on every build. Dropped from that stanza; the versioned `libcec8` it already depends on is the dependency it actually needs, and the packages that do ship binaries keep theirs.

Reformatted to the one-dependency-per-line style the other stanzas use. Not built here (no Debian toolchain on this machine) — the change is confined to that one field.