### PR TITLE
spelling: occured→occurred

### DIFF
--- a/src/libcec/CECClient.cpp
+++ b/src/libcec/CECClient.cpp
@@ -1865,7 +1865,7 @@ void* CCECClient::Process(void)
         case CCallbackWrap::CEC_CB_COMMAND_HANDLER:
           keepResult = cb->Report(CallbackCommandHandler(cb->m_command));
           if (!keepResult)
-            LIB_CEC->AddLog(CEC_LOG_WARNING, "Command callback timeout occured !");
+            LIB_CEC->AddLog(CEC_LOG_WARNING, "Command callback timeout occurred !");
 	  break;
         default:
           break;


### PR DESCRIPTION
Some people advocate strong typing. I advocate good typing.

PS I'm the Debian libcec maintainer, just uploaded 8.x to Debian, which includes rust bindings, nodejs bindings, and working python3 bindings. This is the one upstream patch I'm still carrying.