### PR TITLE
cecc-client --help / --list-devices

### DIFF
--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -128,6 +128,44 @@ static void cec_list_devices(void)
   //TODO
 }
 
+static void cec_show_help_command_line(const char* strExec)
+{
+  printf("\n"
+      "%s {-h|--help|-i|--info|-l|--list-devices|[COM PORT]}\n"
+      "\n"
+      "parameters:\n"
+      "  -h --help                 Shows this help text\n"
+      "  -i --info                 Shows the libCEC version and how it was compiled\n"
+      "  -l --list-devices         List all devices on this system\n"
+      "  -t --type {p|r|t|a|x}     The device type to use: playback, recording, tuner,\n"
+      "                            audio system or tv (x).\n"
+      "  -o --osd-name {osd name}  Use a custom osd name.\n"
+      "  -p --port {int}           The HDMI port to use as active source.\n"
+      "  -b --base {int}           The logical address of the device to which this\n"
+      "                            adapter is connected.\n"
+      "  -r --rom                  Read saved settings from the EEPROM\n"
+      "  -d --log-level {level}    Sets the log level, as the sum of the levels\n"
+      "                            wanted: 1 error, 2 warning, 4 notice, 8 traffic,\n"
+      "                            16 debug, 31 all. See cectypes.h for the values.\n"
+      "  -m --monitor              Start a monitor-only client.\n"
+      "  -s --single-command       Execute a single command and exit.\n"
+      "  -c --command {command}    Execute a single given command and exit. (Implies\n"
+      "                            --single-command)\n"
+      "  [COM PORT]                The com port to connect to. If no COM port is\n"
+      "                            given, the client tries to connect to the first\n"
+      "                            device that is detected.\n"
+      "\n"
+      "commands, read from stdin one per line or given with --command:\n"
+      "  as                        Make this device the active source.\n"
+      "  ea                        Ask the audio system to enable system audio mode.\n"
+      "  da                        Ask the audio system to disable system audio mode.\n"
+      "  gas                       Show the audio system's audio status.\n"
+      "  gsam                      Show whether system audio mode is enabled.\n"
+      "  scan                      Show information about each device on the bus.\n"
+      "  q, quit                   Exit.\n",
+      strExec);
+}
+
 static int cec_process_command_line_arguments(int argc, char *argv[])
 {
   int bReturn = 1;
@@ -252,7 +290,7 @@ static int cec_process_command_line_arguments(int argc, char *argv[])
         if (g_cecLogLevel == -1)
           g_cecLogLevel = CEC_LOG_WARNING + CEC_LOG_ERROR;
 
-//        TODO ShowHelpCommandLine(argv[0]);
+        cec_show_help_command_line(argv[0]);
         return 0;
       }
       else if (!strcmp(argv[iArgPtr], "-b") ||

--- a/src/cecc-client/cecc-client.c
+++ b/src/cecc-client/cecc-client.c
@@ -40,6 +40,7 @@
 #include <fcntl.h>
 #include <stdarg.h>
 #include <inttypes.h>
+#include <time.h>
 #if !defined(__WINDOWS__)
 #include <unistd.h>
 #endif
@@ -125,7 +126,46 @@ static void cb_cec_log_message(void* UNUSED(lib), const cec_log_message* message
 
 static void cec_list_devices(void)
 {
-  //TODO
+  cec_adapter_descriptor devices[10];
+  char buffer[50];
+  int8_t iDevicesFound = g_iface.detect_adapters(g_iface.connection, devices, sizeof(devices) / sizeof(cec_adapter_descriptor), NULL, 0);
+  int8_t iDevicePtr;
+
+  g_iface.version_to_string(g_config.serverVersion, buffer, sizeof(buffer));
+  printf("libCEC version: %s, %s\n", buffer, g_iface.get_lib_info(g_iface.connection));
+
+  if (iDevicesFound <= 0)
+  {
+    printf("Found devices: NONE\n");
+    return;
+  }
+
+  printf("Found devices: %d\n\n", iDevicesFound);
+
+  for (iDevicePtr = 0; iDevicePtr < iDevicesFound; iDevicePtr++)
+  {
+    printf("device:              %d\n", (int)iDevicePtr + 1);
+    printf("com port:            %s\n", devices[iDevicePtr].strComName);
+    printf("vendor id:           %04x\n", (unsigned int)devices[iDevicePtr].iVendorId);
+    printf("product id:          %04x\n", (unsigned int)devices[iDevicePtr].iProductId);
+    printf("firmware version:    %d\n", (int)devices[iDevicePtr].iFirmwareVersion);
+
+    if (devices[iDevicePtr].iFirmwareBuildDate != CEC_FW_BUILD_UNKNOWN)
+    {
+      time_t buildTime = (time_t)devices[iDevicePtr].iFirmwareBuildDate;
+      struct tm* buildTm = gmtime(&buildTime);
+      if (buildTm && strftime(buffer, sizeof(buffer), "%a %b %e %H:%M:%S %Y +0000", buildTm))
+        printf("firmware build date: %s\n", buffer);
+    }
+
+    if (devices[iDevicePtr].adapterType != ADAPTERTYPE_UNKNOWN)
+    {
+      g_iface.adapter_type_to_string(devices[iDevicePtr].adapterType, buffer, sizeof(buffer));
+      printf("type:                %s\n", buffer);
+    }
+
+    printf("\n");
+  }
 }
 
 static void cec_show_help_command_line(const char* strExec)


### PR DESCRIPTION
You folks include cecc-client in the binary package generated by debian/* so I figured I should too in the "official" debian package. But cecc-client --help and cecc-client --list-devices were //TODO so I did.